### PR TITLE
Fix go.mod go version to 1.20

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/example
 
-go 1.19
+go 1.20
 
 require sigs.k8s.io/kube-scheduler-wasm-extension/guest v0.0.0-00010101000000-000000000000
 

--- a/guest/go.mod
+++ b/guest/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/guest
 
-go 1.19
+go 1.20
 
 replace sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto => ../kubernetes/proto
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I tried running `guest/` tests with go 1.20.x and got
```
internal/imports/mem.go:24:24: unsafe.StringData requires go1.20 or later (-lang was set to go1.19; check go.mod)
```
Then I downgraded to go 1.19 (via `brew`) and got:
```
# sigs.k8s.io/kube-scheduler-wasm-extension/guest/internal/imports
internal/imports/mem.go:24:31: undefined: unsafe.StringData
```
So since `unsafe.StringData` is from go 1.20 I guess the guest `go.mod` should specify go 1.20? Most of the repo versions, and kubernetes/kubernetes also, have go 1.20 in their `go.mod`.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?

NONE