### PR TITLE
feature: always assign the same instance to the same Pod

### DIFF
--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -38,7 +38,8 @@ require (
 	github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
-	k8s.io/kubectl v0.0.0
+	k8s.io/component-base v0.26.2
+	k8s.io/kubectl v0.26.2
 	k8s.io/kubernetes v1.26.2
 )
 
@@ -46,26 +47,53 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/cel-go v0.12.6 // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.14.0 // indirect
+	github.com/prometheus/client_model v0.3.0 // indirect
+	github.com/prometheus/common v0.37.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.5 // indirect
@@ -84,65 +112,34 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	k8s.io/cloud-provider v0.0.0 // indirect
-	k8s.io/csi-translation-lib v0.0.0 // indirect
-	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
-	k8s.io/kms v0.26.2 // indirect
-	k8s.io/mount-utils v0.0.0 // indirect
-	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.35 // indirect
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.20.0 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.37.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.26.2 // indirect
 	k8s.io/client-go v0.26.2 // indirect
-	k8s.io/component-base v0.26.2
+	k8s.io/cloud-provider v0.0.0 // indirect
 	k8s.io/component-helpers v0.26.2 // indirect
+	k8s.io/csi-translation-lib v0.0.0 // indirect
+	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
+	k8s.io/kms v0.26.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/kube-scheduler v0.26.2 // indirect
+	k8s.io/kube-scheduler v0.0.0 // indirect
+	k8s.io/mount-utils v0.0.0 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.35 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -650,8 +650,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/scheduler/plugin/export_test.go
+++ b/scheduler/plugin/export_test.go
@@ -1,0 +1,55 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package wasm
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type WasmPlugin struct{ *wasmPlugin }
+
+func NewTestWasmPlugin(p framework.Plugin) (*WasmPlugin, bool) {
+	pl, ok := p.(*wasmPlugin)
+	if !ok {
+		return nil, false
+	}
+
+	return &WasmPlugin{wasmPlugin: pl}, true
+}
+
+func (w *WasmPlugin) GetOrCreateGuest(ctx context.Context, podUID types.UID) (*guest, error) {
+	return w.getOrCreateGuest(ctx, podUID)
+}
+
+func (w *WasmPlugin) ClearGuestModule() {
+	w.guestModule = nil
+}
+
+func (w *WasmPlugin) GetSchedulingPodUID() types.UID {
+	return w.pool.schedulingPodUID
+}
+
+func (w *WasmPlugin) GetAssignedToBindingPod() map[types.UID]*guest {
+	return w.pool.assignedToBindingPod
+}
+
+func (w *WasmPlugin) GetInstanceFromPool() any {
+	return w.pool.pool.Get()
+}

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -22,9 +22,11 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 
@@ -62,13 +64,10 @@ func New(configuration runtime.Object, frameworkHandle framework.Handle) (framew
 		instanceCounter:   atomic.Uint64{},
 	}
 
-	// Eagerly add one instance to the pool. Doing so helps to fail fast.
-	g, err := pl.getOrCreateGuest(ctx)
+	pl.pool, err = pl.newGuestPool(ctx)
 	if err != nil {
-		_ = runtime.Close(ctx)
-		return nil, err
+		return nil, fmt.Errorf("failed to create a guest pool: %w", err)
 	}
-	pl.pool.Put(g)
 
 	return pl, nil
 }
@@ -79,7 +78,99 @@ type wasmPlugin struct {
 	guestModule       wazero.CompiledModule
 	guestModuleConfig wazero.ModuleConfig
 	instanceCounter   atomic.Uint64
-	pool              sync.Pool
+	pool              *guestPool
+}
+
+type guestPool struct {
+	// pool is a pool of unused guest instances.
+	pool sync.Pool
+
+	// scheduledPodUID is the UID of the pod that is being scheduled.
+	schedulingPodUID types.UID
+	// assignedToSchedulingPod has the guest instance assignedToSchedulingPod to the pod.
+	// assignedToSchedulingPod instance won't be put back to the pool until the scheduling cycle of this Pod is finished.
+	assignedToSchedulingPod *guest
+	// assignedToSchedulingPodLock is a lock to protect the access to the assigned instance.
+	// The scheduler may call Filter(), AddPod(), RemovePod() concurrently, and we need to take a lock.
+	// But, other methods of the plugin should be invoked for the same Pod serially.
+	assignedToSchedulingPodLock sync.Mutex
+
+	// assignedToBindingPod has the guest instances for Pods in binding cycle.
+	assignedToBindingPod map[types.UID]*guest
+}
+
+func (pl *wasmPlugin) newGuestPool(ctx context.Context) (*guestPool, error) {
+	p := &guestPool{
+		assignedToBindingPod: make(map[types.UID]*guest),
+	}
+
+	// Eagerly add one instance to the pool. Doing so helps to fail fast.
+	g, createErr := pl.newGuest(ctx)
+	if createErr != nil {
+		return nil, createErr
+	}
+	p.put(g)
+
+	return p, nil
+}
+
+// assign assigns the guest instance to the pod so that the same pod can always get the same guest instance.
+func (g *guestPool) assign(guest *guest, podUID types.UID) {
+	g.assignedToSchedulingPod = guest
+	g.schedulingPodUID = podUID
+}
+
+// assignForBinding assigns the guest instance to the pod for binding cycle.
+// This function doesn't take a lock because it is called in the scheduling cycle meaning it'll never called in parallel.
+func (g *guestPool) assignForBinding(podUID types.UID) {
+	guest := g.assignedToSchedulingPod
+	g.assignedToBindingPod[podUID] = guest
+}
+
+// unassignForBinding unassigns the guest instance from the pod in the binding cycle.
+func (g *guestPool) unassignForBinding(podUID types.UID) {
+	assigned := g.assignedToBindingPod[podUID]
+	delete(g.assignedToBindingPod, podUID)
+	g.put(assigned)
+}
+
+// unassign unassigns the guest instance from the pod and put the instance back to the pool.
+func (g *guestPool) unassign() {
+	assigned := g.assignedToSchedulingPod
+	g.assignedToSchedulingPod = nil
+	g.schedulingPodUID = ""
+	g.put(assigned)
+}
+
+// put puts the guest instance back to the pool.
+func (g *guestPool) put(guest *guest) {
+	g.pool.Put(guest)
+}
+
+// get gets a guest instance for the given Pod.
+// if the pod has already got a guest, it returns the guest.
+// Otherwise, it gets a guest from the pool.
+func (p *guestPool) get(ctx context.Context, podUID types.UID) (*guest, bool) {
+	// Check if the pod has already got a guest.
+	if podUID == p.schedulingPodUID {
+		return p.assignedToSchedulingPod, true
+	}
+
+	// If not, get a guest from the pool.
+	g := p.pool.Get()
+	if g == nil {
+		return nil, false
+	}
+	gue, ok := g.(*guest)
+	if !ok {
+		// shouldn't happen.
+		return nil, false
+	}
+
+	// Assign the guest to the pod.
+	p.assign(gue, podUID)
+
+	return g.(*guest), true
 }
 
 var _ framework.FilterPlugin = (*wasmPlugin)(nil)
@@ -89,31 +180,96 @@ func (pl *wasmPlugin) Name() string {
 	return PluginName
 }
 
-func (pl *wasmPlugin) getOrCreateGuest(ctx context.Context) (*guest, error) {
-	poolG := pl.pool.Get()
-	if poolG == nil {
+func (pl *wasmPlugin) getOrCreateGuest(ctx context.Context, podUID types.UID) (*guest, error) {
+	poolG, ok := pl.pool.get(ctx, podUID)
+	if !ok {
 		if g, createErr := pl.newGuest(ctx); createErr != nil {
 			return nil, createErr
 		} else {
 			poolG = g
+			// Assign this new guest to the pod.
+			pl.pool.assign(poolG, podUID)
 		}
 	}
-	return poolG.(*guest), nil
+
+	return poolG, nil
+}
+
+func (pl *wasmPlugin) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
+}
+
+func (pl *wasmPlugin) PreFilter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
+	// When PreFilter is called, run unassign because the previous scheduling cycle should have been finished.
+	pl.pool.unassign()
+
+	_, err := pl.getOrCreateGuest(ctx, pod.GetUID())
+	if err != nil {
+		return nil, framework.AsStatus(err)
+	}
+
+	// TODO: support PreFilter in wasm guest.
+
+	return nil, nil
 }
 
 // Filter invoked at the filter extension point.
 func (pl *wasmPlugin) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	g, err := pl.getOrCreateGuest(ctx)
+	pl.pool.assignedToSchedulingPodLock.Lock()
+	defer pl.pool.assignedToSchedulingPodLock.Unlock()
+
+	g, err := pl.getOrCreateGuest(ctx, pod.GetUID())
 	if err != nil {
 		return framework.AsStatus(err)
 	}
-	defer pl.pool.Put(g)
 
 	// The guest Wasm may call host functions, so we add context parameters of
 	// the current args.
 	args := &filterArgs{pod: pod, nodeInfo: nodeInfo}
 	ctx = context.WithValue(ctx, filterArgsKey{}, args)
 	return g.filter(ctx)
+}
+
+func (pl *wasmPlugin) AddPod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	pl.pool.assignedToSchedulingPodLock.Lock()
+	defer pl.pool.assignedToSchedulingPodLock.Unlock()
+
+	// TODO: support AddPod in wasm guest.
+	return nil
+}
+
+func (pl *wasmPlugin) RemovePod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	pl.pool.assignedToSchedulingPodLock.Lock()
+	defer pl.pool.assignedToSchedulingPodLock.Unlock()
+
+	// TODO: support RemovePod in wasm guest.
+	return nil
+}
+
+func (pl *wasmPlugin) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+	// assume that the pod is going to binding cycle and continue to assign the instance to the pod.
+	// unassign the instance in Unreserve or PostBind.
+	pl.pool.assignForBinding(p.GetUID())
+
+	// TODO: support Permit in wasm guest.
+
+	return nil, 0
+}
+
+func (pl *wasmPlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	// TODO: support Reserve in wasm guest.
+	// Currently, it's implemented to implement the ReservePlugin interface.
+	return nil
+}
+
+func (pl *wasmPlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	pl.pool.unassignForBinding(p.GetUID())
+	// TODO: support Unreserve in wasm guest.
+}
+
+func (pl *wasmPlugin) PostBind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	pl.pool.unassignForBinding(p.GetUID())
+	// TODO: support PostBind in wasm guest.
 }
 
 // Close implements io.Closer

--- a/scheduler/plugin/plugin_test.go
+++ b/scheduler/plugin/plugin_test.go
@@ -22,10 +22,190 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/testdata"
 )
+
+const exampleWasmPath = "../example/main.wasm"
+
+func Test_getOrCreateGuest(t *testing.T) {
+	p, err := testdata.NewPluginExampleFilterSimple()
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+	defer p.(io.Closer).Close()
+
+	pl, ok := wasm.NewTestWasmPlugin(p)
+	if !ok {
+		t.Fatalf("failed to cast plugin to wasmPlugin: %v", ok)
+	}
+
+	ctx := context.Background()
+	uid := types.UID("test-uid")
+	differentuid := types.UID("test-uid")
+
+	g, err := pl.GetOrCreateGuest(ctx, uid)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g == nil {
+		t.Fatalf("got nil guest instance")
+	}
+
+	// this should creat new guest instance because we pass the different podUID.
+	g, err = pl.GetOrCreateGuest(ctx, differentuid)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g == nil {
+		t.Fatalf("got nil guest instance")
+	}
+
+	// remove guestModule to make sure that the next getOrCreateGuest() doesn't try to create new instance.
+	pl.ClearGuestModule()
+
+	// this should return the same guest instance as the previous one because we pass the same podUID.
+	g, err = pl.GetOrCreateGuest(ctx, uid)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g == nil {
+		t.Fatalf("got nil guest instance")
+	}
+}
+
+// Test_guestPool_assignedToBindingPod tests that the assignedToBindingPod field is set correctly.
+func Test_guestPool_assignedToBindingPod(t *testing.T) {
+	p, err := testdata.NewPluginExampleFilterSimple()
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+	defer p.(io.Closer).Close()
+
+	pl, ok := wasm.NewTestWasmPlugin(p)
+	if !ok {
+		t.Fatalf("failed to cast plugin to wasmPlugin: %v", ok)
+	}
+
+	ctx := context.Background()
+	pod := st.MakePod().UID("uid1").Name("test-pod").Node("good-node").Obj()
+	nextPod := st.MakePod().UID("uid2").Name("test-pod2").Node("good-node").Obj()
+
+	_, status := pl.PreFilter(ctx, nil, pod)
+	if !status.IsSuccess() {
+		t.Fatalf("prefilter failed: %v", status)
+	}
+
+	if pl.GetSchedulingPodUID() != pod.UID {
+		t.Fatalf("expected schedulingPodUID to be %v, got %v", pod.UID, pl.GetSchedulingPodUID())
+	}
+
+	// pod is going to the binding cycle.
+	status, _ = pl.Permit(ctx, nil, pod, "node")
+	if !status.IsSuccess() {
+		t.Fatalf("filter failed: %v", status)
+	}
+
+	if len(pl.GetAssignedToBindingPod()) != 1 {
+		t.Fatalf("expected assignedToBindingPod to have 1 entry for `pod`, got %v", len(pl.GetAssignedToBindingPod()))
+	}
+
+	// another scheduling cycle for nextPod is started.
+
+	_, status = pl.PreFilter(ctx, nil, nextPod)
+	if !status.IsSuccess() {
+		t.Fatalf("prefilter failed: %v", status)
+	}
+
+	if pl.GetSchedulingPodUID() != nextPod.UID {
+		t.Fatalf("expected schedulingPodUID to be %v, got %v", pod.UID, pl.GetSchedulingPodUID())
+	}
+
+	status, _ = pl.Permit(ctx, nil, nextPod, "node")
+	if !status.IsSuccess() {
+		t.Fatalf("filter failed: %v", status)
+	}
+
+	if len(pl.GetAssignedToBindingPod()) != 2 {
+		t.Fatalf("expected assignedToBindingPod to have 2 entry for `pod`, got %v", len(pl.GetAssignedToBindingPod()))
+	}
+
+	// make sure that the assignedToBindingPod has entries for both `pod` and `nextPod`.
+
+	registeredPodUIDs := sets.New[types.UID]()
+	for podUID := range pl.GetAssignedToBindingPod() {
+		registeredPodUIDs.Insert(podUID)
+	}
+	if !registeredPodUIDs.Has(pod.UID) || !registeredPodUIDs.Has(nextPod.UID) {
+		t.Fatalf("expected assignedToBindingPod to have entries for `pod` and `nextPod`, but got %v", registeredPodUIDs)
+	}
+
+	// pod is rejected in the binding cycle.
+	pl.Unreserve(ctx, nil, pod, "node")
+	if len(pl.GetAssignedToBindingPod()) != 1 {
+		t.Fatalf("expected assignedToBindingPod to have 1 entry for `nextPod`, got %v", len(pl.GetAssignedToBindingPod()))
+	}
+	if _, ok := pl.GetAssignedToBindingPod()[nextPod.UID]; !ok {
+		t.Fatalf("expected assignedToBindingPod to have entry for `nextPod`, got %v", pl.GetAssignedToBindingPod())
+	}
+
+	// nextPod is rejected in the binding cycle.
+	pl.PostBind(ctx, nil, nextPod, "node")
+	if len(pl.GetAssignedToBindingPod()) != 0 {
+		t.Fatalf("expected assignedToBindingPod to have 0 entry, got %v", len(pl.GetAssignedToBindingPod()))
+	}
+}
+
+// Test_guestPool_assignedToSchedulingPod tests that the schedulingPodUID is assigned during PreFilter expectedly.
+func Test_guestPool_assignedToSchedulingPod(t *testing.T) {
+	p, err := testdata.NewPluginExampleFilterSimple()
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+	defer p.(io.Closer).Close()
+
+	pl, ok := wasm.NewTestWasmPlugin(p)
+	if !ok {
+		t.Fatalf("failed to cast plugin to wasmPlugin: %v", ok)
+	}
+
+	ctx := context.Background()
+	pod := st.MakePod().UID("uid1").Name("test-pod").Node("good-node").Obj()
+	nextPod := st.MakePod().UID("uid2").Name("test-pod2").Node("good-node").Obj()
+
+	_, status := pl.PreFilter(ctx, nil, pod)
+	if !status.IsSuccess() {
+		t.Fatalf("prefilter failed: %v", status)
+	}
+
+	node := st.MakeNode().Name("good-node").Obj()
+	ni := framework.NewNodeInfo()
+	ni.SetNode(node)
+
+	status = pl.Filter(ctx, nil, pod, ni)
+	if !status.IsSuccess() {
+		t.Fatalf("filter failed: %v", status)
+	}
+
+	if pl.GetSchedulingPodUID() != pod.UID {
+		t.Fatalf("expected schedulingPodUID to be %v, got %v", pod.UID, pl.GetSchedulingPodUID())
+	}
+
+	// PreFilter is called with a different pod, meaning the past scheduling cycle of `pod` is finished.
+	pl.PreFilter(ctx, nil, nextPod)
+
+	if pl.GetSchedulingPodUID() != nextPod.UID {
+		t.Fatalf("expected schedulingPodUID to be %v, got %v", nextPod.UID, pl.GetSchedulingPodUID())
+	}
+
+	if pl.GetInstanceFromPool() == nil {
+		t.Fatal("expected guest instance that is used for `pod` to be in the pool, but it's not")
+	}
+}
 
 func TestFilter(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes the host to always assign the same guest instance to the same Pod.
Two motivations here.

##### 1. support cycle state #16 

This change simplifies the problem how to support the cycle state. That's difficult because users can put any data into cycle state, and we don't know what'll be put.
After this PR, we don't need to pass the cycle state between host and guest; the guest initializes the cycle state inside of it and uses the same cycle state in the same scheduling.

Obviously, this idea means that users cannot pass the data from one plugin to other plugin through the cycle state, but that usecase is rare. (Actually, AFAIK, no in-tree plugins do that) 
Not saying we never support it in the future though, I'd say we don't need to prioritize it.

##### 2. cache resource data

Thanks to the snapshot, the NodeInfo and Pod passed to each extension point aren't get changed during the same scheduling cycle. We don't need to pass them to guest every time we call the guest. The guest can cache them during the same scheduling cycle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #16 

#### Special notes for your reviewer:

Detailed description: https://github.com/kubernetes-sigs/kube-scheduler-wasm-extension/issues/16#issuecomment-1566352602

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
