### PR TITLE
Add profile make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# debug builds are too big to check in
+main-debug.wasm
+
+# don't check in profiler data
+cpu.pprof
+mem.pprof

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,17 @@
 .PHONY: build-tinygo
 build-tinygo: examples/filter-simple/main.wasm examples/noop/main.wasm
 
+%/main-debug.wasm: %/main.go
+	@(cd $(@D); tinygo build -o main-debug.wasm -scheduler=none -target=wasi main.go)
+
+.PHONY: profile
+profile: examples/filter-simple/main-debug.wasm
+	@cd ./internal/e2e; \
+	go run ./profiler/profiler.go ../../$^; \
+	go tool pprof -text cpu.pprof; \
+	go tool pprof -text mem.pprof; \
+	rm cpu.pprof mem.pprof
+
 .PHONY: bench-plugin
 bench-plugin:
 	@(cd internal/e2e; go test -run='^$$' -bench '^BenchmarkPlugin.*$$' . -count=6)

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,6 +4,8 @@ module sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e
 go 1.20
 
 require (
+	github.com/stealthrocket/wzprof v0.1.5
+	github.com/tetratelabs/wazero v1.2.0
 	k8s.io/api v0.26.2
 	k8s.io/kubernetes v1.26.2
 	sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto v0.0.0-00010101000000-000000000000
@@ -57,6 +59,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
@@ -69,7 +72,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29 // indirect
+	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.5.0 // indirect
@@ -82,7 +85,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.26.2 // indirect
-	k8s.io/apiserver v0.26.2 // indirect
 	k8s.io/client-go v0.26.2 // indirect
 	k8s.io/component-base v0.26.2 // indirect
 	k8s.io/component-helpers v0.26.2 // indirect

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -143,6 +143,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20230406165453-00490a63f317 h1:hFhpt7CTmR3DX+b4R19ydQFtofxT0Sv3QsKNMVQYTMQ=
+github.com/google/pprof v0.0.0-20230406165453-00490a63f317/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -234,6 +236,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stealthrocket/wzprof v0.1.5 h1:Y3jQHvdGFQMySV2VIjJhBu08OdcqcflfTz7CvrH5MGM=
+github.com/stealthrocket/wzprof v0.1.5/go.mod h1:hqLzj5iDSncc6rlPMhC51O642AkaC+dWVPNNalZdlCY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -243,8 +247,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29 h1:K5tKyoW4SFY4mGzxxDlEbiltoq8xx7vm32k2BLclieI=
-github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
+github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -270,6 +274,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -542,7 +548,6 @@ k8s.io/api v0.26.2/go.mod h1:1kjMQsFE+QHPfskEcVNgL3+Hp88B80uj0QtSOlj8itU=
 k8s.io/apimachinery v0.26.2 h1:da1u3D5wfR5u2RpLhE/ZtZS2P7QvDgLZTi9wrNZl/tQ=
 k8s.io/apimachinery v0.26.2/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
 k8s.io/apiserver v0.26.2 h1:Pk8lmX4G14hYqJd1poHGC08G03nIHVqdJMR0SD3IH3o=
-k8s.io/apiserver v0.26.2/go.mod h1:GHcozwXgXsPuOJ28EnQ/jXEM9QeG6HT22YxSNmpYNh8=
 k8s.io/client-go v0.26.2 h1:s1WkVujHX3kTp4Zn4yGNFK+dlDXy1bAAkIl+cFAiuYI=
 k8s.io/client-go v0.26.2/go.mod h1:u5EjOuSyBa09yqqyY7m3abZeovO/7D/WehVVlZ2qcqU=
 k8s.io/component-base v0.26.2 h1:IfWgCGUDzrD6wLLgXEstJKYZKAFS2kO+rBRi0p3LqcI=

--- a/internal/e2e/plugin_perf_test.go
+++ b/internal/e2e/plugin_perf_test.go
@@ -27,13 +27,15 @@ import (
 )
 
 func BenchmarkPluginFilter(b *testing.B) {
-	noop, err := testdata.NewPluginExampleNoop()
+	ctx := context.Background()
+
+	noop, err := testdata.NewPluginExampleNoop(ctx)
 	if err != nil {
 		b.Fatalf("failed to create plugin: %v", err)
 	}
 	defer noop.(io.Closer).Close()
 
-	filterSimple, err := testdata.NewPluginExampleFilterSimple()
+	filterSimple, err := testdata.NewPluginExampleFilterSimple(ctx)
 	if err != nil {
 		b.Fatalf("failed to create plugin: %v", err)
 	}
@@ -80,7 +82,7 @@ func BenchmarkPluginFilter(b *testing.B) {
 
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						s := pl.plugin.(framework.FilterPlugin).Filter(context.Background(), nil, tc.pod, ni)
+						s := pl.plugin.(framework.FilterPlugin).Filter(ctx, nil, tc.pod, ni)
 						if want, have := framework.Success, s.Code(); want != have {
 							b.Fatalf("unexpected code: got %v, expected %v, got reason: %v", want, have, s.Message())
 						}

--- a/internal/e2e/profiler/profiler.go
+++ b/internal/e2e/profiler/profiler.go
@@ -1,0 +1,80 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+
+	"github.com/stealthrocket/wzprof"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
+	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/testdata"
+
+	"github.com/tetratelabs/wazero/experimental"
+)
+
+func main() {
+	guestPath := os.Args[1] // must be a debug build
+	guestBin, err := os.ReadFile(guestPath)
+	if err != nil {
+		log.Panicln("error reading", guestPath, ":", err)
+	}
+
+	node := testdata.NodeReal
+	pod := testdata.PodReal
+	ni := framework.NewNodeInfo()
+	ni.SetNode(node)
+
+	// Configure the profiler, which integrates via context configuration.
+	sampleRate := 1.0
+	p := wzprof.ProfilingFor(guestBin)
+	cpu := p.CPUProfiler()
+	mem := p.MemoryProfiler()
+	ctx := context.WithValue(context.Background(),
+		experimental.FunctionListenerFactoryKey{},
+		experimental.MultiFunctionListenerFactory(
+			wzprof.Sample(sampleRate, cpu),
+			wzprof.Sample(sampleRate, mem),
+		),
+	)
+
+	// Pass the profiling context to the plugin.
+	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestPath: guestPath})
+	if err != nil {
+		log.Panicln("failed to create plugin:", err)
+	}
+	defer plugin.(io.Closer).Close()
+
+	// Profile around the Filter function
+	cpu.StartProfile()
+	s := plugin.(framework.FilterPlugin).Filter(ctx, nil, pod, ni)
+	if want, have := framework.Success, s.Code(); want != have {
+		log.Panicln("filter failed:", want, "!=", have, ":", s.Message())
+	}
+	cpuProfile := cpu.StopProfile(sampleRate)
+	memProfile := mem.NewProfile(sampleRate)
+
+	if err := wzprof.WriteProfile("cpu.pprof", cpuProfile); err != nil {
+		log.Panicln("error writing CPU profile:", err)
+	}
+	if err := wzprof.WriteProfile("mem.pprof", memProfile); err != nil {
+		log.Panicln("error writing memory profile:", err)
+	}
+}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -23,7 +23,6 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // for rest client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
-	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 )
 
 func main() {

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -35,7 +35,7 @@ replace (
 )
 
 require (
-	github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29
+	github.com/tetratelabs/wazero v1.2.0
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/kubectl v0.0.0

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -315,8 +315,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29 h1:K5tKyoW4SFY4mGzxxDlEbiltoq8xx7vm32k2BLclieI=
-github.com/tetratelabs/wazero v1.1.1-0.20230520044102-8c7e0caead29/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
+github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -42,8 +42,12 @@ func New(configuration runtime.Object, frameworkHandle framework.Handle) (framew
 		return nil, fmt.Errorf("failed to decode into %s PluginConfig: %w", PluginName, err)
 	}
 
-	ctx := context.Background()
+	return NewFromConfig(context.Background(), config)
+}
 
+// NewFromConfig is like New, except it allows us to explicitly provide the
+// context and configuration of the plugin. This allows flexibility in tests.
+func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, error) {
 	guestBin, err := os.ReadFile(config.GuestPath)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: error reading guest binary at %s: %w", config.GuestPath, err)

--- a/scheduler/plugin/plugin_test.go
+++ b/scheduler/plugin/plugin_test.go
@@ -48,11 +48,12 @@ func TestFilter(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, tt := range tests {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := testdata.NewPluginExampleFilterSimple()
+			p, err := testdata.NewPluginExampleFilterSimple(ctx)
 			if err != nil {
 				t.Fatalf("failed to create plugin: %v", err)
 			}
@@ -60,7 +61,7 @@ func TestFilter(t *testing.T) {
 
 			ni := framework.NewNodeInfo()
 			ni.SetNode(tc.node)
-			s := p.(framework.FilterPlugin).Filter(context.Background(), nil, tc.pod, ni)
+			s := p.(framework.FilterPlugin).Filter(ctx, nil, tc.pod, ni)
 			if s.Code() != tc.expectedCode {
 				t.Fatalf("unexpected code: got %v, expected %v, got reason: %v", s.Code(), tc.expectedCode, s.Message())
 			}

--- a/scheduler/testdata/testdata.go
+++ b/scheduler/testdata/testdata.go
@@ -2,6 +2,7 @@ package testdata
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"fmt"
 	"path"
@@ -15,25 +16,25 @@ import (
 	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/kubectl/pkg/scheme"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework"
-	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
+	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 )
 
 // NewPluginExampleFilterSimple returns a new plugin configured with PathExampleFilterSimple.
-func NewPluginExampleFilterSimple() (frameworkruntime.Plugin, error) {
-	return wasm.New(&apiruntime.Unknown{
-		ContentType: "application/json",
-		Raw:         []byte(fmt.Sprintf(`{"guestName":"filter-simple", "guestPath":"%s"}`, PathExampleFilterSimple)),
-	}, nil)
+func NewPluginExampleFilterSimple(ctx context.Context) (frameworkruntime.Plugin, error) {
+	return wasm.NewFromConfig(ctx, wasm.PluginConfig{
+		GuestName: "filter-simple",
+		GuestPath: PathExampleFilterSimple,
+	})
 }
 
 var PathExampleFilterSimple = pathExample("filter-simple")
 
 // NewPluginExampleNoop returns a new plugin configured with PathExampleNoop.
-func NewPluginExampleNoop() (frameworkruntime.Plugin, error) {
-	return wasm.New(&apiruntime.Unknown{
-		ContentType: "application/json",
-		Raw:         []byte(fmt.Sprintf(`{"guestName":"noop", "guestPath":"%s"}`, PathExampleNoop)),
-	}, nil)
+func NewPluginExampleNoop(ctx context.Context) (frameworkruntime.Plugin, error) {
+	return wasm.NewFromConfig(ctx, wasm.PluginConfig{
+		GuestName: "noop",
+		GuestPath: PathExampleNoop,
+	})
 }
 
 var PathExampleNoop = pathExample("noop")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds the profile make target, which uses wzprof to generate cpu and memory profiling data from the webassembly guest. This is a basic implementation to help people understand the costs of the current plugin. Ideas welcome to simplify the flow.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

here's an example run:

```bash
$ make profile
Main binary filename not available.
Type: cpu
Time: Jun 3, 2023 at 12:43pm (+08)
Duration: 2.11ms, Total samples = 1802.46us (85.52%)
Showing nodes accounting for 1786.46us, 99.11% of 1802.46us total
Dropped 7 nodes (cum <= 9.01us)
      flat  flat%   sum%        cum   cum%
  652.78us 36.22% 36.22%   990.91us 54.98%  runtime.alloc
  174.60us  9.69% 45.90%   174.60us  9.69%  (runtime.gcBlock).state
  163.53us  9.07% 54.98%   163.53us  9.07%  (runtime.gcBlock).setState
  107.92us  5.99% 60.96%   396.75us 22.01%  runtime.stringFromBytes
  100.59us  5.58% 66.54%   527.29us 29.25%  interface:{UnmarshalVT:func:{slice:basic:uint8}{named:error}}.UnmarshalVT$invoke
   83.46us  4.63% 71.17%   422.38us 23.43%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.NodeStatus).UnmarshalVT
   72.25us  4.01% 75.18%   556.96us 30.90%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.PodSpec).UnmarshalVT
   46.54us  2.58% 77.76%     1793us 99.48%  main.nameEqualsPodSpec
   43.17us  2.39% 80.16%   412.04us 22.86%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.Container).UnmarshalVT
   34.87us  1.93% 82.09%   988.71us 54.85%  (sigs.k8s.io/kube-scheduler-wasm-extension/guest.filterArgs).Pod
   33.75us  1.87% 83.97%    57.33us  3.18%  runtime.hashmapSet
   31.04us  1.72% 85.69%   148.21us  8.22%  runtime.hashmapStringSet
   22.34us  1.24% 86.93%   100.50us  5.58%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ContainerStatus).UnmarshalVT
   20.71us  1.15% 88.08%   103.17us  5.72%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.Probe).UnmarshalVT
   20.33us  1.13% 89.20%    51.83us  2.88%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.EnvVar).UnmarshalVT
   20.29us  1.13% 90.33%    93.17us  5.17%  runtime.hashmapMake
   18.25us  1.01% 91.34%    58.17us  3.23%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/meta.Time).UnmarshalVT
   18.17us  1.01% 92.35%   110.62us  6.14%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ResourceRequirements).UnmarshalVT
   17.05us  0.95% 93.30%    54.09us  3.00%  runtime.sliceAppend
   15.88us  0.88% 94.18%    19.67us  1.09%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.SecurityContext).UnmarshalVT
   15.83us  0.88% 95.06%    39.04us  2.17%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ContainerState).UnmarshalVT
   15.54us  0.86% 95.92%    61.29us  3.40%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.HTTPGetAction).UnmarshalVT
   14.33us   0.8% 96.71%    22.67us  1.26%  runtime.hashmapStringHash
   10.12us  0.56% 97.27%    10.12us  0.56%  runtime.hash32
       8us  0.44% 97.72%    22.50us  1.25%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ContainerPort).UnmarshalVT
    7.33us  0.41% 98.13%    17.88us  0.99%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/meta.OwnerReference).UnmarshalVT
    6.13us  0.34% 98.46%  1802.46us   100%  filter
       6us  0.33% 98.80%   133.17us  7.39%  sigs.k8s.io/kube-scheduler-wasm-extension/guest/internal/imports.getBytes
    3.33us  0.18% 98.98%  1796.33us 99.66%  (sigs.k8s.io/kube-scheduler-wasm-extension/guest/api.FilterFunc).Filter
    2.33us  0.13% 99.11%    11.38us  0.63%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ObjectFieldSelector).UnmarshalVT
Main binary filename not available.
Type: alloc_space
Time: Jun 3, 2023 at 12:43pm (+08)
Duration: 80.40ms, Total samples = 26.52kB 
Showing nodes accounting for 26.52kB, 100% of 26.52kB total
Dropped 7 nodes (cum <= 0.13kB)
      flat  flat%   sum%        cum   cum%
   26.52kB   100%   100%    26.52kB   100%  runtime.alloc
         0     0%   100%     3.12kB 11.77%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.Container).UnmarshalVT
         0     0%   100%     0.28kB  1.04%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ContainerState).UnmarshalVT
         0     0%   100%     0.90kB  3.41%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ContainerStatus).UnmarshalVT
         0     0%   100%     0.26kB  0.99%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.EnvVar).UnmarshalVT
         0     0%   100%     0.19kB   0.7%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.HTTPGetAction).UnmarshalVT
         0     0%   100%     6.27kB 23.64%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.NodeStatus).UnmarshalVT
         0     0%   100%     4.13kB 15.56%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.PodSpec).UnmarshalVT
         0     0%   100%     0.39kB  1.47%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.Probe).UnmarshalVT
         0     0%   100%     1.37kB  5.15%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api.ResourceRequirements).UnmarshalVT
         0     0%   100%     0.40kB  1.50%  (*sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/meta.Time).UnmarshalVT
         0     0%   100%    11.69kB 44.07%  (sigs.k8s.io/kube-scheduler-wasm-extension/guest.filterArgs).Pod
         0     0%   100%    26.33kB 99.27%  (sigs.k8s.io/kube-scheduler-wasm-extension/guest/api.FilterFunc).Filter
         0     0%   100%     0.19kB  0.73%  _start
         0     0%   100%    26.33kB 99.27%  filter
         0     0%   100%     5.96kB 22.48%  interface:{UnmarshalVT:func:{slice:basic:uint8}{named:error}}.UnmarshalVT$invoke
         0     0%   100%    26.33kB 99.27%  main.nameEqualsPodSpec
         0     0%   100%     2.75kB 10.37%  runtime.hashmapMake
         0     0%   100%     0.70kB  2.64%  runtime.hashmapSet
         0     0%   100%     1.22kB  4.61%  runtime.hashmapStringSet
         0     0%   100%     0.61kB  2.31%  runtime.sliceAppend
         0     0%   100%     6.15kB 23.19%  runtime.stringFromBytes
         0     0%   100%     7.69kB 28.99%  sigs.k8s.io/kube-scheduler-wasm-extension/guest/internal/imports.getBytes
```

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

N/A tooling only
