### PR TITLE
ci: adds basic setup

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -1,0 +1,63 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/commit.yaml
+---
+name: "build"
+
+on:
+  push:  # We run tests on non-tagged pushes to main
+    tags: ''
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:  # We also run tests on pull requests targeted at the main branch.
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
+  # For example, you can try to build a branch without raising a pull request.
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
+          - "1.20"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false  # cache separately to include golangci-lint
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+            ~/go/pkg/mod
+            ~/go/bin
+          key: check-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum', 'Makefile') }}
+
+      - run: make check
+
+  test-scheduler:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
+          - "1.20"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - run: make test-scheduler

--- a/.github/workflows/testdata.yaml
+++ b/.github/workflows/testdata.yaml
@@ -1,0 +1,54 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/testdata.yaml
+---
+name: "testdata"
+
+on:
+  push:  # We run tests on non-tagged pushes to main
+    tags: ''
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:  # We also run tests on pull requests targeted at the main branch.
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
+  # For example, you can try to build a branch without raising a pull request.
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  # Note: TinyGo is not idempotent when generating wasm, so we neither check in
+  # %.wasm, nor do we verify it matches what's checked in.
+  testdata:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
+          - "1.20"
+        tinygo-version:  # Note: TinyGo only supports latest: https://github.com/tinygo-org/tinygo/releases
+          - "0.27.0"  # Latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: "Set up TinyGo"
+        run: |  # Installing via curl so commands are similar on OS/x
+          tinygo_version=${{ matrix.tinygo-version }}
+          curl -sSL https://github.com/tinygo-org/tinygo/releases/download/v${tinygo_version}/tinygo${tinygo_version}.linux-amd64.tar.gz | sudo tar -C /usr/local -xzf -
+          echo "TINYGOROOT=/usr/local/tinygo" >> $GITHUB_ENV
+          echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
+
+      - name: "Set up wat2wasm"
+        run: |  # Needed for testdata. wabt includes wat2wasm.
+          wabt_version=1.0.33
+          wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-ubuntu.tar.gz
+          curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wat2wasm
+
+      - run: make testdata

--- a/examples/filter-simple/go.mod
+++ b/examples/filter-simple/go.mod
@@ -1,7 +1,9 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/examples/filter-simple
 
-// Match highest TinyGo's supported version of Go: 1.19 as of TinyGo 0.27
-go 1.19
+// TinyGo 0.27 doesn't fully support Go 1.20, but it supports what we need.
+// Particularly, unsafe.SliceData, unsafe.StringData were added to TinyGo 0.27.
+// See https://github.com/tinygo-org/tinygo/commit/c43958972c3ffcd51e65414a346e53779edb9f97
+go 1.20
 
 require sigs.k8s.io/kube-scheduler-wasm-extension/guest v0.0.0-00010101000000-000000000000
 

--- a/examples/noop/go.mod
+++ b/examples/noop/go.mod
@@ -1,7 +1,9 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/examples/noop
 
-// Match highest TinyGo's supported version of Go: 1.19 as of TinyGo 0.27
-go 1.19
+// TinyGo 0.27 doesn't fully support Go 1.20, but it supports what we need.
+// Particularly, unsafe.SliceData, unsafe.StringData were added to TinyGo 0.27.
+// See https://github.com/tinygo-org/tinygo/commit/c43958972c3ffcd51e65414a346e53779edb9f97
+go 1.20
 
 require sigs.k8s.io/kube-scheduler-wasm-extension/guest v0.0.0-00010101000000-000000000000
 

--- a/guest/filter.go
+++ b/guest/filter.go
@@ -20,6 +20,7 @@ package guest
 // Note: this requires tinygo flags: -gc=custom -tags=custommalloc
 import (
 	_ "github.com/wasilibs/nottinygc"
+
 	"sigs.k8s.io/kube-scheduler-wasm-extension/guest/api"
 	"sigs.k8s.io/kube-scheduler-wasm-extension/guest/internal/imports"
 	protoapi "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/api"

--- a/guest/go.mod
+++ b/guest/go.mod
@@ -1,7 +1,9 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/guest
 
-// Match highest TinyGo's supported version of Go: 1.19 as of TinyGo 0.27
-go 1.19
+// TinyGo 0.27 doesn't fully support Go 1.20, but it supports what we need.
+// Particularly, unsafe.SliceData, unsafe.StringData were added to TinyGo 0.27.
+// See https://github.com/tinygo-org/tinygo/commit/c43958972c3ffcd51e65414a346e53779edb9f97
+go 1.20
 
 replace sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto => ../kubernetes/proto
 

--- a/internal/e2e/plugin_perf_test.go
+++ b/internal/e2e/plugin_perf_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+
 	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/test"
 )
 

--- a/kubernetes/proto/api/generated.pb.go
+++ b/kubernetes/proto/api/generated.pb.go
@@ -26,6 +26,7 @@ package v1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	instr "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/instr"
 	meta "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/meta"
 	resource "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/resource"

--- a/kubernetes/proto/api/generated_vtproto.pb.go
+++ b/kubernetes/proto/api/generated_vtproto.pb.go
@@ -30,6 +30,7 @@ import (
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	instr "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/instr"
 	meta "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/meta"
 	resource "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/resource"

--- a/kubernetes/proto/go.mod
+++ b/kubernetes/proto/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto
 
-// Match highest TinyGo's supported version of Go: 1.19 as of TinyGo 0.27
-go 1.19
+// TinyGo 0.27 doesn't fully support Go 1.20, but it supports what we need.
+// Particularly, unsafe.SliceData, unsafe.StringData were added to TinyGo 0.27.
+// See https://github.com/tinygo-org/tinygo/commit/c43958972c3ffcd51e65414a346e53779edb9f97
+go 1.20
 
 require google.golang.org/protobuf v1.30.0

--- a/kubernetes/proto/meta/generated.pb.go
+++ b/kubernetes/proto/meta/generated.pb.go
@@ -26,6 +26,7 @@ package v1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	runtime "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/runtime"
 	_ "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/schema"
 )

--- a/kubernetes/proto/meta/generated_vtproto.pb.go
+++ b/kubernetes/proto/meta/generated_vtproto.pb.go
@@ -30,6 +30,7 @@ import (
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	runtime "sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto/runtime"
 )
 

--- a/scheduler/test/testdata.go
+++ b/scheduler/test/testdata.go
@@ -111,7 +111,6 @@ func relativePath(fromThisFile string) string {
 	p := path.Join(path.Dir(thisFile), fromThisFile)
 	if abs, err := filepath.Abs(p); err != nil {
 		panic(err)
-		return ""
 	} else {
 		return abs
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This sets up basic CI with a couple notable targets:

* `make check`: runs various linters and formatters, and ensures projects build.
* `make test-scheduler`: runs scheduler-based unit and e2e tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Later, we can make tests that run in tinygo for the guest, but as that's tricky I left things here for now.

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

N/A

