### PR TITLE
extracts out pool and stubs plugin functions

### DIFF
--- a/internal/e2e/profiler/profiler.go
+++ b/internal/e2e/profiler/profiler.go
@@ -25,7 +25,9 @@ import (
 	"github.com/stealthrocket/wzprof"
 	"github.com/tetratelabs/wazero/experimental"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+
 	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
+	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/test"
 )
 
 func main() {

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -23,6 +23,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // for rest client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
+
 	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 )
 

--- a/scheduler/plugin/export_test.go
+++ b/scheduler/plugin/export_test.go
@@ -17,8 +17,6 @@
 package wasm
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -32,10 +30,6 @@ func NewTestWasmPlugin(p framework.Plugin) (*WasmPlugin, bool) {
 	}
 
 	return &WasmPlugin{wasmPlugin: pl}, true
-}
-
-func (w *WasmPlugin) GetOrCreateGuest(ctx context.Context, podUID types.UID) (*guest, error) {
-	return w.getOrCreateGuest(ctx, podUID)
 }
 
 func (w *WasmPlugin) ClearGuestModule() {

--- a/scheduler/plugin/guest.go
+++ b/scheduler/plugin/guest.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"k8s.io/kubernetes/pkg/scheduler/framework"
-
 	"github.com/tetratelabs/wazero"
 	wazeroapi "github.com/tetratelabs/wazero/api"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 const (
@@ -85,7 +84,7 @@ func (g *guest) filter(ctx context.Context) *framework.Status {
 		return framework.AsStatus(decorateError(g.out, "filter", err))
 	} else {
 		code := uint32(results[0])
-		reason := filterArgsFromContext(ctx).reason
+		reason := filterParamsFromContext(ctx).reason
 		return framework.NewStatus(framework.Code(code), reason)
 	}
 }

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -20,17 +20,14 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/tetratelabs/wazero"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
-
-	"github.com/tetratelabs/wazero"
 )
 
 const PluginName = "wasm"
@@ -73,7 +70,7 @@ func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, 
 		instanceCounter:   atomic.Uint64{},
 	}
 
-	pl.pool, err = pl.newGuestPool(ctx)
+	pl.pool, err = newGuestPool(ctx, pl.newGuest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a guest pool: %w", err)
 	}
@@ -87,143 +84,52 @@ type wasmPlugin struct {
 	guestModule       wazero.CompiledModule
 	guestModuleConfig wazero.ModuleConfig
 	instanceCounter   atomic.Uint64
-	pool              *guestPool
+	pool              *guestPool[*guest]
 }
 
-// guestPool manages the wasm guest instances.
-// It remember which guest instance is assigned to which pod in scheduling cycle or binding cycle.
-type guestPool struct {
-	// pool is a pool of unused guest instances.
-	pool sync.Pool
+var _ framework.Plugin = (*wasmPlugin)(nil)
 
-	// scheduledPodUID is the UID of the pod that is being scheduled.
-	// The plugin will update this field at the beginning of each scheduling cycle (PreFilter).
-	//
-	// Note: We cannot unassign the guest instance in PostFilter/Permit
-	// because PostFilter is not enough to notice failures in the scheduling cycle,
-	// it's called only when the Pod is rejected in PreFilter or Filter.
-	// So, we need to trach Pods in the scheduling cycle and the binding cycle separately
-	// so that we can know which guest instance to unassign at PreFilter.
-	schedulingPodUID types.UID
-	// assignedToSchedulingPod has the guest instance assignedToSchedulingPod to the pod.
-	// assignedToSchedulingPod instance won't be put back to the pool until the scheduling cycle of this Pod is finished.
-	// The plugin will update this field at the beginning of each scheduling cycle (PreFilter) along with schedulingPodUID.
-	assignedToSchedulingPod *guest
-	// assignedToSchedulingPodLock is a lock to protect the access to the assigned instance.
-	// The scheduler may call Filter(), AddPod(), RemovePod() concurrently, and we need to take a lock.
-	// But, other methods of the plugin should be invoked for the same Pod serially.
-	assignedToSchedulingPodLock sync.Mutex
-
-	// assignedToBindingPod has the guest instances for Pods in binding cycle.
-	assignedToBindingPod map[types.UID]*guest
-}
-
-func (pl *wasmPlugin) newGuestPool(ctx context.Context) (*guestPool, error) {
-	p := &guestPool{
-		assignedToBindingPod: make(map[types.UID]*guest),
-	}
-
-	// Eagerly add one instance to the pool. Doing so helps to fail fast.
-	g, createErr := pl.newGuest(ctx)
-	if createErr != nil {
-		return nil, createErr
-	}
-	p.put(g)
-
-	return p, nil
-}
-
-// assignForScheduling assigns the guest instance to the pod in the scheduling cycle
-// so that the same pod can always get the same guest instance.
-func (g *guestPool) assignForScheduling(guest *guest, podUID types.UID) {
-	g.assignedToSchedulingPod = guest
-	g.schedulingPodUID = podUID
-}
-
-// assignForBinding assigns the guest instance to the pod in the binding cycle.
-// This function doesn't take a lock because it is supposed to be called in the scheduling cycle meaning it'll never called in parallel.
-func (g *guestPool) assignForBinding(podUID types.UID) {
-	guest := g.assignedToSchedulingPod
-	g.assignedToBindingPod[podUID] = guest
-}
-
-// unassignForScheduling unassigns the guest instance from the pod and put the instance back to the pool.
-func (g *guestPool) unassignForScheduling() {
-	assigned := g.assignedToSchedulingPod
-	g.assignedToSchedulingPod = nil
-	g.schedulingPodUID = ""
-	g.put(assigned)
-}
-
-// unassignForBinding unassigns the guest instance from the pod in the binding cycle.
-func (g *guestPool) unassignForBinding(podUID types.UID) {
-	assigned := g.assignedToBindingPod[podUID]
-	delete(g.assignedToBindingPod, podUID)
-	g.put(assigned)
-}
-
-// put puts the guest instance back to the pool.
-func (g *guestPool) put(guest *guest) {
-	g.pool.Put(guest)
-}
-
-// getInstanceForSchedulingPod gets a guest instance for the Pod in the scheduling cycle.
-// If the pod has already got a guest, it returns the guest.
-// Otherwise, it gets a guest from the pool.
-func (p *guestPool) getInstanceForSchedulingPod(ctx context.Context, podUID types.UID) (*guest, bool) {
-	// Check if the pod has already got a guest.
-	if podUID == p.schedulingPodUID {
-		return p.assignedToSchedulingPod, true
-	}
-
-	// If not, get a guest from the pool.
-	g := p.pool.Get()
-	if g == nil {
-		return nil, false
-	}
-	gue, ok := g.(*guest)
-	if !ok {
-		// shouldn't happen.
-		return nil, false
-	}
-
-	return gue, true
-}
-
-var _ framework.FilterPlugin = (*wasmPlugin)(nil)
-
-// Name returns name of the plugin. It is used in logs, etc.
+// Name implements the same method as documented on framework.Plugin.
 func (pl *wasmPlugin) Name() string {
 	return PluginName
 }
 
-func (pl *wasmPlugin) getOrCreateGuest(ctx context.Context, podUID types.UID) (*guest, error) {
-	poolG, ok := pl.pool.getInstanceForSchedulingPod(ctx, podUID)
-	if !ok {
-		if g, createErr := pl.newGuest(ctx); createErr != nil {
-			return nil, createErr
-		} else {
-			poolG = g
-			// Assign this new guest to the pod.
-			pl.pool.assignForScheduling(poolG, podUID)
-		}
-	}
+var _ framework.PreFilterExtensions = (*wasmPlugin)(nil)
 
-	// Assign the guest to the pod.
-	pl.pool.assignForScheduling(poolG, podUID)
+// AddPod implements the same method as documented on framework.PreFilterExtensions.
+func (pl *wasmPlugin) AddPod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	pl.pool.assignedToSchedulingPodLock.Lock()
+	defer pl.pool.assignedToSchedulingPodLock.Unlock()
 
-	return poolG, nil
+	// TODO: support AddPod in wasm guest.
+	return nil
 }
 
+// RemovePod implements the same method as documented on framework.PreFilterExtensions.
+func (pl *wasmPlugin) RemovePod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
+	pl.pool.assignedToSchedulingPodLock.Lock()
+	defer pl.pool.assignedToSchedulingPodLock.Unlock()
+
+	// TODO: support RemovePod in wasm guest.
+	return nil
+}
+
+var _ framework.PreFilterPlugin = (*wasmPlugin)(nil)
+
+// PreFilterExtensions implements the same method as documented on
+// framework.PreFilterPlugin.
 func (pl *wasmPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 
+// PreFilter implements the same method as documented on
+// framework.PreFilterPlugin.
 func (pl *wasmPlugin) PreFilter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
-	// When PreFilter is called, run unassign because the previous scheduling cycle should have been finished.
+	// PreFilter is the first stage in scheduling. If there's an existing guest
+	// association, unassign it, so that we can make a pod-specific one.
 	pl.pool.unassignForScheduling()
 
-	_, err := pl.getOrCreateGuest(ctx, pod.GetUID())
+	_, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
 	if err != nil {
 		return nil, framework.AsStatus(err)
 	}
@@ -233,39 +139,91 @@ func (pl *wasmPlugin) PreFilter(ctx context.Context, _ *framework.CycleState, po
 	return nil, nil
 }
 
-// Filter invoked at the filter extension point.
+var _ framework.FilterPlugin = (*wasmPlugin)(nil)
+
+// Filter implements the same method as documented on framework.FilterPlugin.
 func (pl *wasmPlugin) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
 	pl.pool.assignedToSchedulingPodLock.Lock()
 	defer pl.pool.assignedToSchedulingPodLock.Unlock()
 
-	g, err := pl.getOrCreateGuest(ctx, pod.GetUID())
+	g, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
 	if err != nil {
 		return framework.AsStatus(err)
 	}
 
-	// The guest Wasm may call host functions, so we add context parameters of
-	// the current args.
-	args := &filterArgs{pod: pod, nodeInfo: nodeInfo}
-	ctx = context.WithValue(ctx, filterArgsKey{}, args)
+	// The guest calls host functions to access the pod and node data. Add
+	// this to the context, so that they are accessible.
+	params := &filterParams{pod: pod, nodeInfo: nodeInfo}
+	ctx = context.WithValue(ctx, filterParamsKey{}, params)
 	return g.filter(ctx)
 }
 
-func (pl *wasmPlugin) AddPod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
+var _ framework.PostFilterPlugin = (*wasmPlugin)(nil)
 
-	// TODO: support AddPod in wasm guest.
+// PostFilter implements the same method as documented on framework.PostFilterPlugin.
+func (pl *wasmPlugin) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
+	panic("TODO: PostFilter")
+}
+
+var _ framework.PreScorePlugin = (*wasmPlugin)(nil)
+
+// PreScore implements the same method as documented on framework.PreScorePlugin.
+func (pl *wasmPlugin) PreScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
+	panic("TODO: PreScore")
+}
+
+var _ framework.ScoreExtensions = (*wasmPlugin)(nil)
+
+// NormalizeScore implements the same method as documented on framework.ScoreExtensions.
+func (pl *wasmPlugin) NormalizeScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
+	panic("TODO: PreScore")
+}
+
+var _ framework.ScorePlugin = (*wasmPlugin)(nil)
+
+// Score implements the same method as documented on framework.ScorePlugin.
+func (pl *wasmPlugin) Score(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (int64, *framework.Status) {
+	panic("TODO: Score")
+}
+
+// ScoreExtensions implements the same method as documented on framework.ScorePlugin.
+func (pl *wasmPlugin) ScoreExtensions() framework.ScoreExtensions {
+	panic("TODO: Score")
+}
+
+var _ framework.ReservePlugin = (*wasmPlugin)(nil)
+
+// Reserve implements the same method as documented on framework.ReservePlugin.
+func (pl *wasmPlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	// TODO: support Reserve in wasm guest.
+	// Currently, it's implemented to implement the ReservePlugin interface.
 	return nil
 }
 
-func (pl *wasmPlugin) RemovePod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
-
-	// TODO: support RemovePod in wasm guest.
-	return nil
+// Unreserve implements the same method as documented on framework.ReservePlugin.
+func (pl *wasmPlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	pl.pool.unassignForBinding(p.GetUID())
+	// TODO: support Unreserve in wasm guest.
 }
 
+var _ framework.PreBindPlugin = (*wasmPlugin)(nil)
+
+// PreBind implements the same method as documented on framework.PreBindPlugin.
+func (pl *wasmPlugin) PreBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+	panic("TODO: PreBind")
+}
+
+var _ framework.PostBindPlugin = (*wasmPlugin)(nil)
+
+// PostBind implements the same method as documented on framework.PostBindPlugin.
+func (pl *wasmPlugin) PostBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
+	pl.pool.unassignForBinding(pod.GetUID())
+	// TODO: support PostBind in wasm guest.
+}
+
+var _ framework.PermitPlugin = (*wasmPlugin)(nil)
+
+// Permit implements the same method as documented on framework.PermitPlugin.
 func (pl *wasmPlugin) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
 	// assume that the pod is going to binding cycle and continue to assign the instance to the pod.
 	// unassign the instance in Unreserve or PostBind.
@@ -276,20 +234,11 @@ func (pl *wasmPlugin) Permit(ctx context.Context, state *framework.CycleState, p
 	return nil, 0
 }
 
-func (pl *wasmPlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	// TODO: support Reserve in wasm guest.
-	// Currently, it's implemented to implement the ReservePlugin interface.
-	return nil
-}
+var _ framework.BindPlugin = (*wasmPlugin)(nil)
 
-func (pl *wasmPlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
-	pl.pool.unassignForBinding(p.GetUID())
-	// TODO: support Unreserve in wasm guest.
-}
-
-func (pl *wasmPlugin) PostBind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
-	pl.pool.unassignForBinding(p.GetUID())
-	// TODO: support PostBind in wasm guest.
+// Bind implements the same method as documented on framework.BindPlugin.
+func (pl *wasmPlugin) Bind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+	panic("TODO: Bind")
 }
 
 // Close implements io.Closer

--- a/scheduler/plugin/plugin_test.go
+++ b/scheduler/plugin/plugin_test.go
@@ -26,56 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+
 	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 	"sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/test"
 )
 
 var ctx = context.Background()
-
-func Test_getOrCreateGuest(t *testing.T) {
-	p, err := test.NewPluginExampleFilterSimple(ctx)
-	if err != nil {
-		t.Fatalf("failed to create plugin: %v", err)
-	}
-	defer p.(io.Closer).Close()
-
-	pl, ok := wasm.NewTestWasmPlugin(p)
-	if !ok {
-		t.Fatalf("failed to cast plugin to wasmPlugin: %v", ok)
-	}
-
-	uid := types.UID("test-uid")
-	differentuid := types.UID("test-uid")
-
-	g, err := pl.GetOrCreateGuest(ctx, uid)
-	if err != nil {
-		t.Fatalf("failed to get guest instance: %v", err)
-	}
-	if g == nil {
-		t.Fatalf("got nil guest instance")
-	}
-
-	// this should creat new guest instance because we pass the different podUID.
-	g, err = pl.GetOrCreateGuest(ctx, differentuid)
-	if err != nil {
-		t.Fatalf("failed to get guest instance: %v", err)
-	}
-	if g == nil {
-		t.Fatalf("got nil guest instance")
-	}
-
-	// remove guestModule to make sure that the next getOrCreateGuest() doesn't try to create new instance.
-	pl.ClearGuestModule()
-
-	// this should return the same guest instance as the previous one because we pass the same podUID.
-	g, err = pl.GetOrCreateGuest(ctx, uid)
-	if err != nil {
-		t.Fatalf("failed to get guest instance: %v", err)
-	}
-	if g == nil {
-		t.Fatalf("got nil guest instance")
-	}
-}
 
 // Test_guestPool_assignedToBindingPod tests that the assignedToBindingPod field is set correctly.
 func Test_guestPool_assignedToBindingPod(t *testing.T) {
@@ -201,7 +157,6 @@ func Test_guestPool_assignedToSchedulingPod(t *testing.T) {
 
 	if pl.GetInstanceFromPool() == nil {
 		t.Fatal("expected guest instance that is used for `pod` to be in the pool, but it's not")
-
 	}
 }
 

--- a/scheduler/plugin/pool.go
+++ b/scheduler/plugin/pool.go
@@ -1,0 +1,142 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package wasm
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// guestPool manages guest to pod assignments in a scheduling or binding cycle.
+type guestPool[guest any] struct {
+	// newGuest is a function to create a new guest.
+	newGuest func(context.Context) (guest, error)
+
+	// pool is a pool of unused guest instances.
+	pool sync.Pool
+
+	// schedulingPodUID is the UID of the pod that is being scheduled.
+	// The plugin updates this field at the beginning of each scheduling cycle (PreFilter).
+	//
+	// Note: We cannot unassign the guest instance in PostFilter/Permit
+	// because PostFilter is not enough to notice failures in the scheduling cycle,
+	// it's called only when the Pod is rejected in PreFilter or Filter.
+	// So, we need to trach Pods in the scheduling cycle and the binding cycle separately
+	// so that we can know which guest instance to unassign at PreFilter.
+	schedulingPodUID types.UID
+
+	// assignedToSchedulingPod has the guest instance assignedToSchedulingPod to the pod.
+	// assignedToSchedulingPod instance won't be put back to the pool until the scheduling cycle of this Pod is finished.
+	// The plugin will update this field at the beginning of each scheduling cycle (PreFilter) along with schedulingPodUID.
+	assignedToSchedulingPod guest
+
+	// assignedToSchedulingPodLock is a lock to protect the access to the assigned instance.
+	// The scheduler may call Filter(), AddPod(), RemovePod() concurrently, and we need to take a lock.
+	// But, other methods of the plugin should be invoked for the same Pod serially.
+	assignedToSchedulingPodLock sync.Mutex
+
+	// assignedToBindingPod has the guest instances for Pods in binding cycle.
+	assignedToBindingPod map[types.UID]guest
+}
+
+func newGuestPool[guest any](ctx context.Context, newGuest func(context.Context) (guest, error)) (*guestPool[guest], error) {
+	p := &guestPool[guest]{
+		newGuest:             newGuest,
+		assignedToBindingPod: make(map[types.UID]guest),
+	}
+
+	// Eagerly add one instance to the pool. Doing so helps to fail fast.
+	g, createErr := newGuest(ctx)
+	if createErr != nil {
+		return nil, createErr
+	}
+	p.put(g)
+
+	return p, nil
+}
+
+func (p *guestPool[guest]) getOrCreateGuest(ctx context.Context, podUID types.UID) (g guest, err error) {
+	var ok bool
+	if g, ok = p.getInstanceForSchedulingPod(ctx, podUID); !ok {
+		if g, err = p.newGuest(ctx); err != nil {
+			return
+		}
+	}
+
+	// Assign the guest to the pod.
+	p.assignForScheduling(g, podUID)
+
+	return
+}
+
+// assignForScheduling assigns the guest instance to the pod in the scheduling
+// cycle, so that the same pod can always get the same guest instance.
+func (p *guestPool[guest]) assignForScheduling(g guest, podUID types.UID) {
+	p.assignedToSchedulingPod = g
+	p.schedulingPodUID = podUID
+}
+
+// assignForBinding assigns the guest instance to the pod in the binding cycle.
+// This function doesn't take a lock because it is supposed to be called in the
+// scheduling cycle: it will never be called in parallel.
+func (p *guestPool[guest]) assignForBinding(podUID types.UID) {
+	g := p.assignedToSchedulingPod
+	p.assignedToBindingPod[podUID] = g
+}
+
+// unassignForScheduling unassigns the guest instance from the pod puts it back
+// into the pool.
+func (p *guestPool[guest]) unassignForScheduling() {
+	assigned := p.assignedToSchedulingPod
+	var zero guest
+	p.assignedToSchedulingPod = zero
+	p.schedulingPodUID = ""
+	p.put(assigned)
+}
+
+// unassignForBinding unassigns the guest instance from the pod in the binding
+// cycle.
+func (p *guestPool[guest]) unassignForBinding(podUID types.UID) {
+	assigned := p.assignedToBindingPod[podUID]
+	delete(p.assignedToBindingPod, podUID)
+	p.put(assigned)
+}
+
+// put puts the guest instance back to the pool.
+func (p *guestPool[guest]) put(g guest) {
+	p.pool.Put(g)
+}
+
+// getInstanceForSchedulingPod gets a guest instance for the Pod in the
+// scheduling cycle. If the pod has already got a guest, it returns the guest.
+// Otherwise, it gets a guest from the pool.
+func (p *guestPool[guest]) getInstanceForSchedulingPod(ctx context.Context, podUID types.UID) (g guest, ok bool) {
+	// Check if the pod has already got a guest.
+	if podUID == p.schedulingPodUID {
+		return p.assignedToSchedulingPod, true
+	}
+
+	// If not, get a guest from the pool.
+	pG := p.pool.Get()
+	if pG == nil {
+		return
+	}
+	g, ok = pG.(guest)
+	return
+}

--- a/scheduler/plugin/pool_test.go
+++ b/scheduler/plugin/pool_test.go
@@ -1,0 +1,77 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package wasm
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var ctx = context.Background()
+
+type testGuest struct {
+	val int
+}
+
+func Test_guestPool_getOrCreateGuest(t *testing.T) {
+	uid := types.UID("test-uid")
+	differentUID := types.UID("different-uid")
+
+	var counter int
+	pl, err := newGuestPool(ctx, func(ctx2 context.Context) (*testGuest, error) {
+		counter++
+		return &testGuest{val: counter}, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+
+	g1, err := pl.getOrCreateGuest(ctx, uid)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g1 == nil {
+		t.Fatalf("have nil guest instance")
+	}
+
+	// We expect a new guest instance when created with a different podUID.
+	g2, err := pl.getOrCreateGuest(ctx, differentUID)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g2 == nil {
+		t.Fatalf("have nil guest instance")
+	}
+	if g2 == g1 {
+		t.Fatalf("expected different guests, but they are the same")
+	}
+
+	// Put the first back into the pool
+	pl.put(g1)
+
+	// This should return the first guest instance because we pass the same
+	// podUID.
+	g3, err := pl.getOrCreateGuest(ctx, uid)
+	if err != nil {
+		t.Fatalf("failed to get guest instance: %v", err)
+	}
+	if g3 != g1 {
+		t.Fatalf("unexpected guest: want %v, have %v", g1, g3)
+	}
+}

--- a/scheduler/test/testdata.go
+++ b/scheduler/test/testdata.go
@@ -16,6 +16,7 @@ import (
 	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/kubectl/pkg/scheme"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework"
+
 	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This extracts the guest pool into its own type so that it can be unit tested without export helpers. Notably, this makes it a generic type which makes testing a lot easier. In the process, I found and fixed a test bug.

This also stubs all the host-side plugins in declaration order according to the framework interface. This helps me understand what we are implementing, and allows the IDE to find the upstream documentation vs guessing.

https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/interface.go#L304-L506

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

N/A