### PR TITLE
fix(host): remove lock from Score

### DIFF
--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -231,9 +231,6 @@ var _ framework.ScorePlugin = (*wasmPlugin)(nil)
 
 // Score implements the same method as documented on framework.ScorePlugin.
 func (pl *wasmPlugin) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
-
 	g, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
 	if err != nil {
 		return 0, framework.AsStatus(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The scheduling framework doesn't call Score() of the same plugin in parallel. So, we don't need to have `pl.pool.assignedToSchedulingPodLock.Lock()`, it's the lock to protect the guest from using at the same time.

ref:  https://github.com/kubernetes/kubernetes/blob/be14b026e33b682c52750741a2256373e480b7d7/pkg/scheduler/framework/runtime/framework.go#L1037

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### What are the benchmark results of this change?
<!--
If documentation-only or trivial, just write "N/A". Otherwise, run the following:

1. `make bench-plugin > before.txt` on the commit prior to your changes
2. `make bench-plugin > after.txt` on the commit of your changes
3. Paste the output of `benchstat before.txt after.txt` as a code block.

If you haven't yet installed benchstat, it looks like this.
```
$ go install golang.org/x/perf/cmd/benchstat@latest
```

-->
```benchstat
(trivial)
```
