### PR TITLE
Switches from UID to pointer for identifying cycle IDs

### DIFF
--- a/internal/e2e/plugin_perf_test.go
+++ b/internal/e2e/plugin_perf_test.go
@@ -60,9 +60,12 @@ func BenchmarkPluginFilter(b *testing.B) {
 
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						s := pl.plugin.(framework.FilterPlugin).Filter(ctx, nil, tc.pod, ni)
+						// Intentionally change the pointer to simulate a new scheduling cycle.
+						pod := *tc.pod
+
+						s := pl.plugin.(framework.FilterPlugin).Filter(ctx, nil, &pod, ni)
 						if want, have := framework.Success, s.Code(); want != have {
-							b.Fatalf("unexpected code: got %v, expected %v, got reason: %v", want, have, s.Message())
+							b.Fatalf("unexpected code: have %v, expected %v, have reason: %v", want, have, s.Message())
 						}
 					}
 				})
@@ -98,9 +101,12 @@ func BenchmarkPluginScore(b *testing.B) {
 				b.Run(tc.name, func(b *testing.B) {
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						_, s := pl.plugin.(framework.ScorePlugin).Score(ctx, nil, tc.pod, tc.pod.Spec.NodeName)
+						// Intentionally change the pointer to simulate a new scheduling cycle.
+						pod := *tc.pod
+
+						_, s := pl.plugin.(framework.ScorePlugin).Score(ctx, nil, &pod, pod.Spec.NodeName)
 						if want, have := framework.Success, s.Code(); want != have {
-							b.Fatalf("unexpected status code: got %v, expected %v, got reason: %v", want, have, s.Message())
+							b.Fatalf("unexpected status code: have %v, expected %v, have reason: %v", want, have, s.Message())
 						}
 					}
 				})
@@ -142,13 +148,16 @@ func BenchmarkPluginFilterAndScore(b *testing.B) {
 
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
-						s := pl.plugin.(framework.FilterPlugin).Filter(ctx, nil, tc.pod, ni)
+						// Intentionally change the pointer to simulate a new scheduling cycle.
+						pod := *tc.pod
+
+						s := pl.plugin.(framework.FilterPlugin).Filter(ctx, nil, &pod, ni)
 						if want, have := framework.Success, s.Code(); want != have {
-							b.Fatalf("unexpected code: got %v, expected %v, got reason: %v", want, have, s.Message())
+							b.Fatalf("unexpected code: have %v, expected %v, have reason: %v", want, have, s.Message())
 						}
-						_, s = pl.plugin.(framework.ScorePlugin).Score(ctx, nil, tc.pod, tc.pod.Spec.NodeName)
+						_, s = pl.plugin.(framework.ScorePlugin).Score(ctx, nil, &pod, tc.pod.Spec.NodeName)
 						if want, have := framework.Success, s.Code(); want != have {
-							b.Fatalf("unexpected status code: got %v, expected %v, got reason: %v", want, have, s.Message())
+							b.Fatalf("unexpected status code: have %v, expected %v, have reason: %v", want, have, s.Message())
 						}
 					}
 				})

--- a/scheduler/plugin/export_test.go
+++ b/scheduler/plugin/export_test.go
@@ -28,14 +28,13 @@ func NewTestWasmPlugin(p framework.Plugin) *WasmPlugin {
 }
 
 func (w *WasmPlugin) SetGlobals(globals map[string]int32) {
-	g, err := w.pool.getForScheduling(ctx, 0)
-	if err != nil {
+	if err := w.pool.doWithSchedulingGuest(ctx, 0, func(g *guest) {
+		// Use test conventions to set a global used to test value range.
+		for n, v := range globals {
+			g.guest.ExportedGlobal(n + "_global").(wazeroapi.MutableGlobal).Set(uint64(v))
+		}
+	}); err != nil {
 		panic(err)
-	}
-
-	// Use test conventions to set a global used to test value range.
-	for n, v := range globals {
-		g.guest.ExportedGlobal(n + "_global").(wazeroapi.MutableGlobal).Set(uint64(v))
 	}
 }
 

--- a/scheduler/plugin/export_test.go
+++ b/scheduler/plugin/export_test.go
@@ -18,7 +18,6 @@ package wasm
 
 import (
 	wazeroapi "github.com/tetratelabs/wazero/api"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -29,9 +28,7 @@ func NewTestWasmPlugin(p framework.Plugin) *WasmPlugin {
 }
 
 func (w *WasmPlugin) SetGlobals(globals map[string]int32) {
-	defer w.pool.unassignForScheduling()
-
-	g, err := w.pool.getOrCreateGuest(ctx, "a")
+	g, err := w.pool.getForScheduling(ctx, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -46,14 +43,14 @@ func (w *WasmPlugin) ClearGuestModule() {
 	w.guestModule = nil
 }
 
-func (w *WasmPlugin) GetSchedulingPodUID() types.UID {
-	return w.pool.schedulingPodUID
+func (w *WasmPlugin) GetSchedulingCycleID() uint32 {
+	return w.pool.schedulingCycleID
 }
 
-func (w *WasmPlugin) GetAssignedToBindingPod() map[types.UID]*guest {
-	return w.pool.assignedToBindingPod
+func (w *WasmPlugin) GetBindingCycles() map[uint32]*guest {
+	return w.pool.binding
 }
 
-func (w *WasmPlugin) GetInstanceFromPool() any {
-	return w.pool.pool.Get()
+func (w *WasmPlugin) GetFreePool() []*guest {
+	return w.pool.free
 }

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/tetratelabs/wazero"
 	v1 "k8s.io/api/core/v1"
@@ -146,20 +147,12 @@ var _ framework.PreFilterExtensions = (*wasmPlugin)(nil)
 
 // AddPod implements the same method as documented on framework.PreFilterExtensions.
 func (pl *wasmPlugin) AddPod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
-
-	// TODO: support AddPod in wasm guest.
-	return nil
+	panic("TODO: scheduling: AddPod")
 }
 
 // RemovePod implements the same method as documented on framework.PreFilterExtensions.
 func (pl *wasmPlugin) RemovePod(ctx context.Context, state *framework.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *framework.Status {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
-
-	// TODO: support RemovePod in wasm guest.
-	return nil
+	panic("TODO: scheduling: RemovePod")
 }
 
 var _ framework.PreFilterPlugin = (*wasmPlugin)(nil)
@@ -167,22 +160,18 @@ var _ framework.PreFilterPlugin = (*wasmPlugin)(nil)
 // PreFilterExtensions implements the same method as documented on
 // framework.PreFilterPlugin.
 func (pl *wasmPlugin) PreFilterExtensions() framework.PreFilterExtensions {
-	return nil
+	panic("TODO: scheduling: PreFilterExtensions")
 }
 
 // PreFilter implements the same method as documented on
 // framework.PreFilterPlugin.
 func (pl *wasmPlugin) PreFilter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
-	// PreFilter is the first stage in scheduling. If there's an existing guest
-	// association, unassign it, so that we can make a pod-specific one.
-	pl.pool.unassignForScheduling()
-
-	_, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
+	_, err := pl.pool.getForScheduling(ctx, cycleID(pod))
 	if err != nil {
 		return nil, framework.AsStatus(err)
 	}
 
-	// TODO: support PreFilter in wasm guest.
+	// TODO: partially implemented for testing
 
 	return nil, nil
 }
@@ -191,10 +180,7 @@ var _ framework.FilterPlugin = (*wasmPlugin)(nil)
 
 // Filter implements the same method as documented on framework.FilterPlugin.
 func (pl *wasmPlugin) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	pl.pool.assignedToSchedulingPodLock.Lock()
-	defer pl.pool.assignedToSchedulingPodLock.Unlock()
-
-	g, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
+	g, err := pl.pool.getForScheduling(ctx, cycleID(pod))
 	if err != nil {
 		return framework.AsStatus(err)
 	}
@@ -210,28 +196,28 @@ var _ framework.PostFilterPlugin = (*wasmPlugin)(nil)
 
 // PostFilter implements the same method as documented on framework.PostFilterPlugin.
 func (pl *wasmPlugin) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
-	panic("TODO: PostFilter")
+	panic("TODO: scheduling: PostFilter")
 }
 
 var _ framework.PreScorePlugin = (*wasmPlugin)(nil)
 
 // PreScore implements the same method as documented on framework.PreScorePlugin.
 func (pl *wasmPlugin) PreScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
-	panic("TODO: PreScore")
+	panic("TODO: scheduling: PreScore")
 }
 
 var _ framework.ScoreExtensions = (*wasmPlugin)(nil)
 
 // NormalizeScore implements the same method as documented on framework.ScoreExtensions.
 func (pl *wasmPlugin) NormalizeScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
-	panic("TODO: PreScore")
+	panic("TODO: scheduling: NormalizeScore")
 }
 
 var _ framework.ScorePlugin = (*wasmPlugin)(nil)
 
 // Score implements the same method as documented on framework.ScorePlugin.
 func (pl *wasmPlugin) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
-	g, err := pl.pool.getOrCreateGuest(ctx, pod.GetUID())
+	g, err := pl.pool.getForScheduling(ctx, cycleID(pod))
 	if err != nil {
 		return 0, framework.AsStatus(err)
 	}
@@ -245,48 +231,59 @@ func (pl *wasmPlugin) Score(ctx context.Context, state *framework.CycleState, po
 
 // ScoreExtensions implements the same method as documented on framework.ScorePlugin.
 func (pl *wasmPlugin) ScoreExtensions() framework.ScoreExtensions {
-	panic("TODO: Score")
+	panic("TODO: scheduling: ScoreExtensions")
 }
 
 var _ framework.ReservePlugin = (*wasmPlugin)(nil)
 
 // Reserve implements the same method as documented on framework.ReservePlugin.
-func (pl *wasmPlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	// TODO: support Reserve in wasm guest.
-	// Currently, it's implemented to implement the ReservePlugin interface.
+func (pl *wasmPlugin) Reserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
+	_, err := pl.pool.getForScheduling(ctx, cycleID(pod))
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+
+	// TODO: partially implemented for testing
+
 	return nil
 }
 
 // Unreserve implements the same method as documented on framework.ReservePlugin.
-func (pl *wasmPlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
-	pl.pool.unassignForBinding(p.GetUID())
-	// TODO: support Unreserve in wasm guest.
+func (pl *wasmPlugin) Unreserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
+	// Note: Unlike the below diagram, this is not a part of the scheduling
+	// cycle, rather the binding on error.
+	// https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#extension-points
+
+	cycleID := cycleID(pod)
+	defer pl.pool.freeFromBinding(cycleID) // the cycle is over, put it back into the pool.
+
+	// TODO: partially implemented for testing
 }
 
 var _ framework.PreBindPlugin = (*wasmPlugin)(nil)
 
 // PreBind implements the same method as documented on framework.PreBindPlugin.
 func (pl *wasmPlugin) PreBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
-	panic("TODO: PreBind")
+	panic("TODO: binding: PreBind")
 }
 
 var _ framework.PostBindPlugin = (*wasmPlugin)(nil)
 
 // PostBind implements the same method as documented on framework.PostBindPlugin.
 func (pl *wasmPlugin) PostBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
-	pl.pool.unassignForBinding(pod.GetUID())
-	// TODO: support PostBind in wasm guest.
+	cycleID := cycleID(pod)
+	defer pl.pool.freeFromBinding(cycleID) // the cycle is over, put it back into the pool.
+
+	// TODO: partially implemented for testing
 }
 
 var _ framework.PermitPlugin = (*wasmPlugin)(nil)
 
 // Permit implements the same method as documented on framework.PermitPlugin.
-func (pl *wasmPlugin) Permit(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
-	// assume that the pod is going to binding cycle and continue to assign the instance to the pod.
-	// unassign the instance in Unreserve or PostBind.
-	pl.pool.assignForBinding(p.GetUID())
+func (pl *wasmPlugin) Permit(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (*framework.Status, time.Duration) {
+	_ = pl.pool.getForBinding(cycleID(pod))
 
-	// TODO: support Permit in wasm guest.
+	// TODO: partially implemented for testing
 
 	return nil, 0
 }
@@ -295,7 +292,7 @@ var _ framework.BindPlugin = (*wasmPlugin)(nil)
 
 // Bind implements the same method as documented on framework.BindPlugin.
 func (pl *wasmPlugin) Bind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
-	panic("TODO: Bind")
+	panic("TODO: binding: Bind")
 }
 
 // Close implements io.Closer
@@ -305,4 +302,17 @@ func (pl *wasmPlugin) Close() error {
 		return rt.Close(context.Background())
 	}
 	return nil
+}
+
+// cycleID is stable through a scheduling or binding cycle. For example, it
+// will be different when the same pod is rescheduled due to an error. The
+// cycleID is not derived from the v1.Pod UID for this reason.
+//
+// We use the last 32-bits of the pod's pointer as its ID, as the struct is
+// re-instantiated each scheduling cycle, but the same object is used for each
+// callback within one.
+// See https://github.com/kubernetes/kubernetes/blob/9740bc0e0a10aad753cf7fcbed0c7be25ab200dd/pkg/scheduler/schedule_one.go#L133
+func cycleID(pod *v1.Pod) uint32 {
+	podPtr := uintptr(unsafe.Pointer(pod))
+	return uint32(podPtr)
 }

--- a/scheduler/plugin/pool.go
+++ b/scheduler/plugin/pool.go
@@ -19,124 +19,131 @@ package wasm
 import (
 	"context"
 	"sync"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // guestPool manages guest to pod assignments in a scheduling or binding cycle.
-type guestPool[guest any] struct {
+//
+// Assumptions made about the lifecycle are taken from the below diagram
+// https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#extension-points
+type guestPool[guest comparable] struct {
 	// newGuest is a function to create a new guest.
 	newGuest func(context.Context) (guest, error)
 
-	// pool is a pool of unused guest instances.
-	pool sync.Pool
+	mux sync.RWMutex
 
-	// schedulingPodUID is the UID of the pod that is being scheduled.
-	// The plugin updates this field at the beginning of each scheduling cycle (PreFilter).
-	//
-	// Note: We cannot unassign the guest instance in PostFilter/Permit
-	// because PostFilter is not enough to notice failures in the scheduling cycle,
-	// it's called only when the Pod is rejected in PreFilter or Filter.
-	// So, we need to trach Pods in the scheduling cycle and the binding cycle separately
-	// so that we can know which guest instance to unassign at PreFilter.
-	schedulingPodUID types.UID
+	// scheduled is up to one guest in the scheduling cycle.
+	schedulingCycleID uint32
+	scheduled         guest
 
-	// assignedToSchedulingPod has the guest instance assignedToSchedulingPod to the pod.
-	// assignedToSchedulingPod instance won't be put back to the pool until the scheduling cycle of this Pod is finished.
-	// The plugin will update this field at the beginning of each scheduling cycle (PreFilter) along with schedulingPodUID.
-	assignedToSchedulingPod guest
+	// binding are any guests in the binding cycle.
+	binding map[uint32]guest
 
-	// assignedToSchedulingPodLock is a lock to protect the access to the assigned instance.
-	// The scheduler may call Filter(), AddPod(), RemovePod() concurrently, and we need to take a lock.
-	// But, other methods of the plugin should be invoked for the same Pod serially.
-	assignedToSchedulingPodLock sync.Mutex
-
-	// assignedToBindingPod has the guest instances for Pods in binding cycle.
-	assignedToBindingPod map[types.UID]guest
+	// free pool of guests not in use
+	free []guest
 }
 
-func newGuestPool[guest any](ctx context.Context, newGuest func(context.Context) (guest, error)) (*guestPool[guest], error) {
-	p := &guestPool[guest]{
-		newGuest:             newGuest,
-		assignedToBindingPod: make(map[types.UID]guest),
-	}
-
+func newGuestPool[guest comparable](ctx context.Context, newGuest func(context.Context) (guest, error)) (*guestPool[guest], error) {
 	// Eagerly add one instance to the pool. Doing so helps to fail fast.
 	g, createErr := newGuest(ctx)
 	if createErr != nil {
 		return nil, createErr
 	}
-	p.put(g)
 
-	return p, nil
+	return &guestPool[guest]{
+		newGuest: newGuest,
+		binding:  make(map[uint32]guest),
+		free:     []guest{g},
+	}, nil
 }
 
-func (p *guestPool[guest]) getOrCreateGuest(ctx context.Context, podUID types.UID) (g guest, err error) {
-	var ok bool
-	if g, ok = p.getInstanceForSchedulingPod(ctx, podUID); !ok {
-		if g, err = p.newGuest(ctx); err != nil {
-			return
-		}
-	}
+// getForScheduling returns a guest for the current cycleID or an error.
+//
+// There can be up to one scheduling cycle in-progress, so this returns the
+// current guest, possibly reclaimed from a prior cycle. Otherwise, one will
+// be created.
+func (p *guestPool[guest]) getForScheduling(ctx context.Context, cycleID uint32) (guest, error) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
-	// Assign the guest to the pod.
-	p.assignForScheduling(g, podUID)
+	// The scheduling cycle runs sequentially. If we still have an association,
+	// take it over.
+	p.schedulingCycleID = cycleID
 
-	return
-}
-
-// assignForScheduling assigns the guest instance to the pod in the scheduling
-// cycle, so that the same pod can always get the same guest instance.
-func (p *guestPool[guest]) assignForScheduling(g guest, podUID types.UID) {
-	p.assignedToSchedulingPod = g
-	p.schedulingPodUID = podUID
-}
-
-// assignForBinding assigns the guest instance to the pod in the binding cycle.
-// This function doesn't take a lock because it is supposed to be called in the
-// scheduling cycle: it will never be called in parallel.
-func (p *guestPool[guest]) assignForBinding(podUID types.UID) {
-	g := p.assignedToSchedulingPod
-	p.assignedToBindingPod[podUID] = g
-}
-
-// unassignForScheduling unassigns the guest instance from the pod puts it back
-// into the pool.
-func (p *guestPool[guest]) unassignForScheduling() {
-	assigned := p.assignedToSchedulingPod
 	var zero guest
-	p.assignedToSchedulingPod = zero
-	p.schedulingPodUID = ""
-	p.put(assigned)
+	if scheduled := p.scheduled; scheduled != zero {
+		// TODO: consider explicitly resetting the guest when
+		// schedulingCycleID != cycleID
+		return scheduled, nil
+	}
+
+	// Prefer the free pool
+	if len(p.free) > 0 {
+		g := p.free[0]
+		p.free = p.free[1:]
+		p.scheduled = g
+		return g, nil
+	}
+
+	// If we're at this point, the guest previously scheduled was re-assigned
+	// to the binding cycle. Create a new guest.
+	if g, err := p.newGuest(ctx); err == nil {
+		p.scheduled = g
+		return g, nil
+	} else {
+		return zero, err
+	}
 }
 
-// unassignForBinding unassigns the guest instance from the pod in the binding
-// cycle.
-func (p *guestPool[guest]) unassignForBinding(podUID types.UID) {
-	assigned := p.assignedToBindingPod[podUID]
-	delete(p.assignedToBindingPod, podUID)
-	p.put(assigned)
+// getForBinding returns a guest for the current cycleID or an error.
+//
+// There can be multiple scheduling cycles in-progress, but they always start
+// after a schedule. If there's an existing association with the cycleID, it
+// is re-used. Otherwise, the current scheduling guest is re-associated for
+// binding.
+func (p *guestPool[guest]) getForBinding(cycleID uint32) guest {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	// Fast path is we are in an existing binding cycle.
+	var zero guest
+	if g := p.binding[cycleID]; g != zero {
+		return g // current guest is still correct.
+	}
+
+	// The pod pointer of the scheduling cycle will differ from the pointer in
+	// the binding one. Take over the currently scheduled guest.
+	if scheduled := p.scheduled; scheduled != zero {
+		p.schedulingCycleID = 0
+		p.scheduled = zero
+		p.binding[cycleID] = scheduled
+		return scheduled
+	}
+
+	// Reaching here is unexpected, because the binding cycle must happen after
+	// a scheduling one, even if binding cycles can run in parallel.
+	panic("unexpected pod pointer")
 }
 
-// put puts the guest instance back to the pool.
+// freeFromBinding should be called when a binding cycle ends for any reason.
+func (p *guestPool[guest]) freeFromBinding(cycleID uint32) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if g, ok := p.binding[cycleID]; ok {
+		delete(p.binding, cycleID)
+		p.put(g)
+	}
+}
+
+// put puts the guest instance back to the pool. This must be called under a
+// lock.
 func (p *guestPool[guest]) put(g guest) {
-	p.pool.Put(g)
-}
-
-// getInstanceForSchedulingPod gets a guest instance for the Pod in the
-// scheduling cycle. If the pod has already got a guest, it returns the guest.
-// Otherwise, it gets a guest from the pool.
-func (p *guestPool[guest]) getInstanceForSchedulingPod(ctx context.Context, podUID types.UID) (g guest, ok bool) {
-	// Check if the pod has already got a guest.
-	if podUID == p.schedulingPodUID {
-		return p.assignedToSchedulingPod, true
+	var zero guest
+	if g == zero {
+		panic("nil guest")
 	}
 
-	// If not, get a guest from the pool.
-	pG := p.pool.Get()
-	if pG == nil {
-		return
-	}
-	g, ok = pG.(guest)
-	return
+	// TODO consider allowing the guest to reset its state
+
+	p.free = append(p.free, g)
 }

--- a/scheduler/plugin/pool_test.go
+++ b/scheduler/plugin/pool_test.go
@@ -41,8 +41,10 @@ func Test_guestPool_getForScheduling(t *testing.T) {
 		t.Fatalf("failed to get guest instance: %v", err)
 	}
 
-	g1, err := pl.getForScheduling(ctx, id)
-	if err != nil {
+	var g1 *testGuest
+	if err = pl.doWithSchedulingGuest(ctx, id, func(t *testGuest) {
+		g1 = t
+	}); err != nil {
 		t.Fatalf("failed to get guest instance: %v", err)
 	}
 	if g1 == nil {
@@ -50,8 +52,10 @@ func Test_guestPool_getForScheduling(t *testing.T) {
 	}
 
 	// Scheduling is sequential, so we expect a different ID to re-use the prior
-	g2, err := pl.getForScheduling(ctx, differentID)
-	if err != nil {
+	var g2 *testGuest
+	if err = pl.doWithSchedulingGuest(ctx, differentID, func(t *testGuest) {
+		g2 = t
+	}); err != nil {
 		t.Fatalf("failed to get guest instance: %v", err)
 	}
 	if g2 == nil {
@@ -76,8 +80,10 @@ func Test_guestPool_getForBinding(t *testing.T) {
 	}
 
 	// assign for scheduling
-	g1, err := pl.getForScheduling(ctx, id)
-	if err != nil {
+	var g1 *testGuest
+	if err = pl.doWithSchedulingGuest(ctx, id, func(t *testGuest) {
+		g1 = t
+	}); err != nil {
 		t.Fatalf("failed to get guest instance: %v", err)
 	}
 
@@ -93,8 +99,10 @@ func Test_guestPool_getForBinding(t *testing.T) {
 	}
 
 	// assign another for scheduling
-	g2, err := pl.getForScheduling(ctx, differentID)
-	if err != nil {
+	var g2 *testGuest
+	if err = pl.doWithSchedulingGuest(ctx, differentID, func(t *testGuest) {
+		g2 = t
+	}); err != nil {
 		t.Fatalf("failed to get guest instance: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Before, we used the UID to identify which cycle is in progress. However, when a scheduling cycle fails, the same UID can happen the next time.

This uses the pointer instead as this is different per run, and easier to compare in wasm. We use the lower bits as that's likely to not conflict, easier to use in wasm, and also can't identify fully the real host memory address.

Finally, this resets the pointer between benchmark runs. This makes sure a run isn't accidentally faster. Before, it was faster due to colliding on the same UID. By resetting the pointer, we avoid re-creating that issue.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

I noticed curious results in the prior PR. The current results look a lot more realistic

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

```
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e
BenchmarkPluginFilter
BenchmarkPluginFilter/noop-wat
BenchmarkPluginFilter/noop-wat/params:_small
BenchmarkPluginFilter/noop-wat/params:_small-12         	 4514036	       271.1 ns/op
BenchmarkPluginFilter/noop-wat/params:_real
BenchmarkPluginFilter/noop-wat/params:_real-12          	 4434201	       263.2 ns/op
BenchmarkPluginFilter/noop
BenchmarkPluginFilter/noop/params:_small
BenchmarkPluginFilter/noop/params:_small-12             	 3605126	       335.3 ns/op
BenchmarkPluginFilter/noop/params:_real
BenchmarkPluginFilter/noop/params:_real-12              	 3170498	       339.0 ns/op
BenchmarkPluginFilter/test
BenchmarkPluginFilter/test/params:_small
BenchmarkPluginFilter/test/params:_small-12             	  154036	      7219 ns/op
BenchmarkPluginFilter/test/params:_real
BenchmarkPluginFilter/test/params:_real-12              	    9352	    121479 ns/op
BenchmarkPluginScore
BenchmarkPluginScore/noop-wat
BenchmarkPluginScore/noop-wat/params:_small
BenchmarkPluginScore/noop-wat/params:_small-12          	 4664058	       257.6 ns/op
BenchmarkPluginScore/noop-wat/params:_real
BenchmarkPluginScore/noop-wat/params:_real-12           	 4602486	       261.2 ns/op
BenchmarkPluginScore/noop
BenchmarkPluginScore/noop/params:_small
BenchmarkPluginScore/noop/params:_small-12              	 3169807	       377.1 ns/op
BenchmarkPluginScore/noop/params:_real
BenchmarkPluginScore/noop/params:_real-12               	 3494535	       344.6 ns/op
BenchmarkPluginScore/test
BenchmarkPluginScore/test/params:_small
BenchmarkPluginScore/test/params:_small-12              	  283779	      4048 ns/op
BenchmarkPluginScore/test/params:_real
BenchmarkPluginScore/test/params:_real-12               	   22026	     54050 ns/op
BenchmarkPluginFilterAndScore
BenchmarkPluginFilterAndScore/noop-wat
BenchmarkPluginFilterAndScore/noop-wat/params:_small
BenchmarkPluginFilterAndScore/noop-wat/params:_small-12 	 3251036	       367.1 ns/op
BenchmarkPluginFilterAndScore/noop-wat/params:_real
BenchmarkPluginFilterAndScore/noop-wat/params:_real-12  	 3233397	       369.3 ns/op
BenchmarkPluginFilterAndScore/noop
BenchmarkPluginFilterAndScore/noop/params:_small
BenchmarkPluginFilterAndScore/noop/params:_small-12     	 2127667	       565.0 ns/op
BenchmarkPluginFilterAndScore/noop/params:_real
BenchmarkPluginFilterAndScore/noop/params:_real-12      	 2246898	       531.6 ns/op
BenchmarkPluginFilterAndScore/test
BenchmarkPluginFilterAndScore/test/params:_small
BenchmarkPluginFilterAndScore/test/params:_small-12     	  105128	     10904 ns/op
BenchmarkPluginFilterAndScore/test/params:_real
BenchmarkPluginFilterAndScore/test/params:_real-12      	    5520	    211922 ns/op
```