### PR TITLE
Updates wazero to 1.2.1

### DIFF
--- a/guest/internal/imports/mem.go
+++ b/guest/internal/imports/mem.go
@@ -45,8 +45,8 @@ func stringToPtr(s string) (uint32, uint32) {
 // don't need to copy them.
 func update(
 	fn func(ptr uint32, limit bufLimit) (len uint32),
-	updater func([]byte) error) error {
-
+	updater func([]byte) error,
+) error {
 	// Run the update function, which returns the size needed, possibly larger
 	// than our buffer.
 	size := fn(uint32(readBufPtr), readBufLimit)

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.20
 
 require (
 	github.com/stealthrocket/wzprof v0.1.5
-	github.com/tetratelabs/wazero v1.2.0
+	github.com/tetratelabs/wazero v1.2.1
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/kubernetes v1.26.2

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -247,8 +247,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
-github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
+github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -35,7 +35,7 @@ replace (
 )
 
 require (
-	github.com/tetratelabs/wazero v1.2.0
+	github.com/tetratelabs/wazero v1.2.1
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/component-base v0.26.2

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -315,8 +315,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
-github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
+github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We're constantly tracking performance concerns and updating to the latest wazero release makes notable improvements without any change to the guest.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Performance related changes in the latest patch were thanks to @ncruces

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

```benchstat
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e
                                               │  v1.2.0.txt  │            v1.2.1.txt             │
                                               │    sec/op    │   sec/op     vs base              │
PluginFilter/noop-wat/params:_small-12           267.4n ±  2%   257.6n ± 4%  -3.65% (p=0.024 n=6)
PluginFilter/noop-wat/params:_real-12            270.4n ±  1%   270.1n ± 1%       ~ (p=0.623 n=6)
PluginFilter/noop/params:_small-12               333.2n ±  1%   329.2n ± 0%  -1.19% (p=0.002 n=6)
PluginFilter/noop/params:_real-12                337.0n ±  0%   336.2n ± 1%       ~ (p=0.701 n=6)
PluginFilter/test/params:_small-12               6.770µ ±  0%   6.279µ ± 0%  -7.25% (p=0.002 n=6)
PluginFilter/test/params:_real-12                122.6µ ±  5%   114.7µ ± 1%  -6.51% (p=0.002 n=6)
PluginScore/noop-wat/params:_small-12            256.2n ±  2%   257.8n ± 0%       ~ (p=0.327 n=6)
PluginScore/noop-wat/params:_real-12             260.2n ±  1%   260.6n ± 2%       ~ (p=0.331 n=6)
PluginScore/noop/params:_small-12                374.0n ±  1%   375.4n ± 1%       ~ (p=0.626 n=6)
PluginScore/noop/params:_real-12                 343.2n ±  1%   348.3n ± 1%  +1.49% (p=0.004 n=6)
PluginScore/test/params:_small-12                3.786µ ±  1%   3.604µ ± 0%  -4.82% (p=0.002 n=6)
PluginScore/test/params:_real-12                 43.48µ ± 16%   46.18µ ± 1%       ~ (p=0.394 n=6)
PluginFilterAndScore/noop-wat/params:_small-12   378.8n ±  3%   376.1n ± 1%       ~ (p=0.061 n=6)
PluginFilterAndScore/noop-wat/params:_real-12    382.1n ±  1%   380.9n ± 0%       ~ (p=0.074 n=6)
PluginFilterAndScore/noop/params:_small-12       576.7n ±  1%   578.0n ± 1%       ~ (p=0.260 n=6)
PluginFilterAndScore/noop/params:_real-12        543.1n ±  1%   543.4n ± 0%       ~ (p=0.509 n=6)
PluginFilterAndScore/test/params:_small-12       10.62µ ±  0%   10.06µ ± 1%  -5.23% (p=0.002 n=6)
PluginFilterAndScore/test/params:_real-12        176.5µ ±  0%   168.0µ ± 1%  -4.80% (p=0.002 n=6)
geomean                                          1.450µ         1.429µ       -1.48%
```
