### PR TITLE
Changes guest index back to UID

### DIFF
--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -35,6 +35,7 @@ replace (
 )
 
 require (
+	github.com/google/uuid v1.1.2
 	github.com/tetratelabs/wazero v1.2.1
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
@@ -71,7 +72,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect

--- a/scheduler/plugin/export_test.go
+++ b/scheduler/plugin/export_test.go
@@ -18,6 +18,8 @@ package wasm
 
 import (
 	wazeroapi "github.com/tetratelabs/wazero/api"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -28,7 +30,7 @@ func NewTestWasmPlugin(p framework.Plugin) *WasmPlugin {
 }
 
 func (w *WasmPlugin) SetGlobals(globals map[string]int32) {
-	if err := w.pool.doWithSchedulingGuest(ctx, 0, func(g *guest) {
+	if err := w.pool.doWithSchedulingGuest(ctx, uuid.NewUUID(), func(g *guest) {
 		// Use test conventions to set a global used to test value range.
 		for n, v := range globals {
 			g.guest.ExportedGlobal(n + "_global").(wazeroapi.MutableGlobal).Set(uint64(v))
@@ -42,11 +44,11 @@ func (w *WasmPlugin) ClearGuestModule() {
 	w.guestModule = nil
 }
 
-func (w *WasmPlugin) GetSchedulingCycleID() uint32 {
-	return w.pool.schedulingCycleID
+func (w *WasmPlugin) GetScheduledPodUID() types.UID {
+	return w.pool.scheduledPodUID
 }
 
-func (w *WasmPlugin) GetBindingCycles() map[uint32]*guest {
+func (w *WasmPlugin) GetBindingCycles() map[types.UID]*guest {
 	return w.pool.binding
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In #39 we switched from using the pod UID to the pointer due to a problem identifying of how to handle the same pod being rescheduled sequentially on error. @sanposhiho found that since `PreFilter` must always be called, we can reset state always on that hook. A later change can instruct the guest to always dump any cache on `PreFilter` even if the UID is the same as last time. Meanwhile, this change mechanically switches the host-side index back to the pod UID.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

```benchstat
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e
                                               │  before.txt  │             after.txt             │
                                               │    sec/op    │   sec/op     vs base              │
PluginFilter/noop-wat/params:_small-12            266.8n ± 0%   263.2n ± 0%  -1.31% (p=0.002 n=6)
PluginFilter/noop-wat/params:_real-12             270.8n ± 0%   268.4n ± 1%  -0.85% (p=0.009 n=6)
PluginFilter/noop/params:_small-12                331.2n ± 1%   327.9n ± 2%       ~ (p=0.084 n=6)
PluginFilter/noop/params:_real-12                 337.2n ± 0%   332.9n ± 2%       ~ (p=0.065 n=6)
PluginFilter/test/params:_small-12                6.486µ ± 2%   6.290µ ± 1%  -3.02% (p=0.002 n=6)
PluginFilter/test/params:_real-12                 115.0µ ± 2%   115.3µ ± 1%       ~ (p=0.589 n=6)
PluginScore/noop-wat/params:_small-12             260.3n ± 0%   257.2n ± 0%  -1.21% (p=0.002 n=6)
PluginScore/noop-wat/params:_real-12              265.5n ± 0%   260.8n ± 1%  -1.75% (p=0.002 n=6)
PluginScore/noop/params:_small-12                 379.5n ± 0%   375.7n ± 1%  -1.00% (p=0.004 n=6)
PluginScore/noop/params:_real-12                  351.8n ± 0%   347.6n ± 3%       ~ (p=0.394 n=6)
PluginScore/test/params:_small-12                 3.619µ ± 1%   3.602µ ± 1%       ~ (p=0.061 n=6)
PluginScore/test/params:_real-12                  40.51µ ± 1%   40.00µ ± 1%       ~ (p=0.093 n=6)
PluginFilterAndScore/noop-wat/params:_small-12    379.2n ± 0%   378.4n ± 1%       ~ (p=0.071 n=6)
PluginFilterAndScore/noop-wat/params:_real-12     384.2n ± 0%   383.3n ± 2%       ~ (p=0.968 n=6)
PluginFilterAndScore/noop/params:_small-12        574.8n ± 0%   572.9n ± 1%       ~ (p=0.145 n=6)
PluginFilterAndScore/noop/params:_real-12         543.1n ± 0%   541.4n ± 0%  -0.31% (p=0.024 n=6)
PluginFilterAndScore/test/params:_small-12       10.091µ ± 1%   9.929µ ± 1%  -1.62% (p=0.004 n=6)
PluginFilterAndScore/test/params:_real-12         168.4µ ± 1%   165.9µ ± 1%  -1.49% (p=0.002 n=6)
geomean                                           1.430µ        1.416µ       -1.02%
```
