### PR TITLE
deps: updates to wazero 1.3.0

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.20
 
 require (
 	github.com/stealthrocket/wzprof v0.1.5
-	github.com/tetratelabs/wazero v1.2.1
+	github.com/tetratelabs/wazero v1.3.0
 	k8s.io/api v0.27.3
 	k8s.io/kubernetes v1.27.3
 	sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto v0.0.0-00010101000000-000000000000

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -251,8 +251,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
-github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.3.0 h1:nqw7zCldxE06B8zSZAY0ACrR9OH5QCcPwYmYlwtcwtE=
+github.com/tetratelabs/wazero v1.3.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -36,7 +36,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/tetratelabs/wazero v1.2.1
+	github.com/tetratelabs/wazero v1.3.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/component-base v0.27.3

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -320,8 +320,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
-github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.3.0 h1:nqw7zCldxE06B8zSZAY0ACrR9OH5QCcPwYmYlwtcwtE=
+github.com/tetratelabs/wazero v1.3.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This updates to wazero 1.3.0, which is Go 1.21 ready.

Go 1.21 will be out in August, and this allows us to use release candidates prior without risk.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

https://github.com/tetratelabs/wazero/releases/tag/v1.3.0

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

The performance has degraded since last change, but I don't recommend skipping this version. I'll start a thread offline in case someone has ideas.

```benchstat
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e
                                                        │  1.2.1.txt  │             1.3.0.txt             │
                                                        │   sec/op    │   sec/op     vs base              │
PluginPreFilter/noop-wat/params:_small-12                 132.4n ± 1%   132.1n ± 0%       ~ (p=0.784 n=6)
PluginPreFilter/noop-wat/params:_real-12                  133.2n ± 1%   132.3n ± 1%  -0.71% (p=0.048 n=6)
PluginPreFilter/noop/params:_small-12                     298.3n ± 4%   297.1n ± 0%       ~ (p=0.699 n=6)
PluginPreFilter/noop/params:_real-12                      297.0n ± 1%   296.9n ± 1%       ~ (p=0.853 n=6)
PluginPreFilter/test/params:_small-12                     4.274µ ± 0%   4.376µ ± 1%  +2.39% (p=0.002 n=6)
PluginPreFilter/test/params:_real-12                      45.73µ ± 1%   49.19µ ± 1%  +7.58% (p=0.002 n=6)
PluginFilter/noop-wat/params:_small-12                    266.1n ± 0%   264.4n ± 0%  -0.64% (p=0.002 n=6)
PluginFilter/noop-wat/params:_real-12                     268.0n ± 1%   265.0n ± 0%  -1.12% (p=0.002 n=6)
PluginFilter/noop/params:_small-12                        472.9n ± 3%   477.1n ± 0%       ~ (p=0.065 n=6)
PluginFilter/noop/params:_real-12                         473.6n ± 1%   477.5n ± 1%  +0.81% (p=0.004 n=6)
PluginFilter/test/params:_small-12                        7.739µ ± 0%   7.823µ ± 1%  +1.09% (p=0.002 n=6)
PluginFilter/test/params:_real-12                         112.1µ ± 0%   114.8µ ± 1%  +2.42% (p=0.002 n=6)
PluginScore/noop-wat/params:_small-12                     267.9n ± 0%   266.3n ± 0%  -0.58% (p=0.002 n=6)
PluginScore/noop-wat/params:_real-12                      269.0n ± 1%   267.1n ± 0%       ~ (p=0.058 n=6)
PluginScore/noop/params:_small-12                         534.5n ± 1%   534.5n ± 0%       ~ (p=1.000 n=6)
PluginScore/noop/params:_real-12                          486.0n ± 2%   489.2n ± 1%       ~ (p=0.234 n=6)
PluginScore/test/params:_small-12                         4.466µ ± 1%   4.481µ ± 1%       ~ (p=0.102 n=6)
PluginScore/test/params:_real-12                          46.51µ ± 1%   48.26µ ± 1%  +3.75% (p=0.002 n=6)
PluginPrefilterFilterAndScore/noop-wat/params:_small-12   399.4n ± 1%   397.6n ± 0%       ~ (p=0.058 n=6)
PluginPrefilterFilterAndScore/noop-wat/params:_real-12    400.5n ± 0%   398.3n ± 1%       ~ (p=0.069 n=6)
PluginPrefilterFilterAndScore/noop/params:_small-12       709.9n ± 2%   712.2n ± 2%       ~ (p=0.084 n=6)
PluginPrefilterFilterAndScore/noop/params:_real-12        727.8n ± 1%   737.7n ± 4%  +1.36% (p=0.004 n=6)
PluginPrefilterFilterAndScore/test/params:_small-12       8.629µ ± 2%   8.959µ ± 1%  +3.82% (p=0.002 n=6)
PluginPrefilterFilterAndScore/test/params:_real-12        113.1µ ± 1%   118.4µ ± 2%  +4.66% (p=0.002 n=6)
geomean                                                   1.349µ        1.363µ       +1.01%
```
