### PR TITLE
allow the scheduler configuration to have multi wasm plugins

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -82,21 +82,6 @@ noted below, and also there are options for mitigation not yet implemented:
     * [polyglot][3] can generate code from protos and might automatically convert
       protos to its more efficient representation.
 
-## Why doesn't the ABI to set the plugin name?
-
-Framework plugins all share a base type `Plugin` with only one method: `Name`.
-This is conventionally set to the same constant used to register the plugin
-factory `app.WithPlugin`. Effectively, this is static configuration because
-there is no configuration you can read prior to invoking this.
-
-Until this changes, there's no reason to define an ABI for the name of a
-wasm plugin. Even if we could read it from the guest, the plugin name would
-have already been associated with the factory. This has some problems until
-something changes:
-
-* There can only be one wasm based plugin defined at a time.
-* Wasm plugins with significantly different behavior will use the same metrics.
-
 ## How is `framework.CycleState` implemented in WebAssembly?
 
 `framework.CycleState` is a primarily a key value storage. Plugins store values

--- a/internal/e2e/profiler/profiler.go
+++ b/internal/e2e/profiler/profiler.go
@@ -67,7 +67,9 @@ func main() {
 	)
 
 	// Pass the profiling context to the plugin.
-	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: "file://" + guestPath})
+	plugin, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{
+		GuestURL: "file://" + guestPath,
+	})
 	if err != nil {
 		log.Panicln("failed to create plugin:", err)
 	}

--- a/internal/e2e/scheduler/scheduler_test.go
+++ b/internal/e2e/scheduler/scheduler_test.go
@@ -40,7 +40,7 @@ import (
 func TestCycleStateCoherence(t *testing.T) {
 	ctx := context.Background()
 
-	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: test.URLTestCycleState})
+	plugin, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: test.URLTestCycleState})
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -193,7 +193,7 @@ func newNodeNumberPlugin(ctx context.Context, t e2e.Testing, advanced, reverse b
 	if advanced {
 		guestURL = test.URLExampleAdvanced
 	}
-	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{
+	plugin, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{
 		GuestURL:    guestURL,
 		LogSeverity: logSeverity,
 		GuestConfig: fmt.Sprintf(`{"reverse": %v}`, reverse),

--- a/internal/e2e/scheduler_perf/scheduler_perf_test.go
+++ b/internal/e2e/scheduler_perf/scheduler_perf_test.go
@@ -99,8 +99,9 @@ var (
 	}
 	registory frameworkruntime.Registry = frameworkruntime.Registry{
 		nodenumberplugin.Name: nodenumberplugin.New,
-		wasm.PluginName:       wasm.New,
+		pluginName:            wasm.PluginFactory(pluginName),
 	}
+	pluginName = "wasm"
 )
 
 // testCase defines a set of test cases that intends to test the performance of

--- a/scheduler/cmd/scheduler/config.go
+++ b/scheduler/cmd/scheduler/config.go
@@ -1,0 +1,99 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	_ "k8s.io/component-base/metrics/prometheus/version" // for version metric registration
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+
+	wasm "sigs.k8s.io/kube-scheduler-wasm-extension/scheduler/plugin"
+)
+
+// getWasmPluginsFromConfig parses the scheduler configuration specified with --config option,
+// and return the wasm plugins enabled by the user.
+func getWasmPluginsFromConfig() ([]string, error) {
+	// In the scheduler, the path to the scheduler configuration is specified with --config option.
+	configFile := flag.String("config", "", "")
+	flag.Parse()
+
+	if configFile == nil {
+		// Users don't have the own configuration. do nothing.
+		return nil, nil
+	}
+
+	cfg, err := loadConfigFromFile(*configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return getWasmPluginNames(cfg), nil
+}
+
+// getWasmPluginNames returns the wasm plugin names enabled by the user.
+// It assumes that the wasm plugin is specified as the multi-point plugin.
+func getWasmPluginNames(cc *config.KubeSchedulerConfiguration) []string {
+	names := []string{}
+	for _, profile := range cc.Profiles {
+		wasmplugins := sets.New[string]()
+		// look for the wasm plugin in the plugin config.
+		for _, config := range profile.PluginConfig {
+			if err := frameworkruntime.DecodeInto(config.Args, &wasm.PluginConfig{}); err != nil {
+				// not wasm plugin.
+				continue
+			}
+
+			wasmplugins.Insert(config.Name)
+		}
+
+		// look for the wasm plugin in the enabled plugins.
+		// (assuming that the wasm plugin is specified as a multi-point plugin.)
+		for _, plugin := range profile.Plugins.MultiPoint.Enabled {
+			if wasmplugins.Has(plugin.Name) {
+				names = append(names, plugin.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func loadConfigFromFile(path string) (*config.KubeSchedulerConfiguration, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// The UniversalDecoder runs defaulting and returns the internal type by default.
+	obj, gvk, err := scheme.Codecs.UniversalDecoder().Decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cfgObj, ok := obj.(*config.KubeSchedulerConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type: %v", gvk)
+	}
+	return cfgObj, nil
+}

--- a/scheduler/cmd/scheduler/config_test.go
+++ b/scheduler/cmd/scheduler/config_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	_ "k8s.io/component-base/logs/json/register"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	_ "k8s.io/component-base/metrics/prometheus/version"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+)
+
+func Test_getWasmPluginNames(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		cc *config.KubeSchedulerConfiguration
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "no wasm plugin",
+			args: args{
+				cc: &config.KubeSchedulerConfiguration{
+					Profiles: []config.KubeSchedulerProfile{
+						{
+							SchedulerName: "default-scheduler",
+							Plugins: &config.Plugins{
+								MultiPoint: config.PluginSet{
+									Enabled: []config.Plugin{
+										{Name: "DefaultPreemption"},
+										{Name: "InterPodAffinity"},
+									},
+								},
+							},
+							PluginConfig: []config.PluginConfig{
+								{
+									Name: "DefaultPreemption",
+									Args: &config.DefaultPreemptionArgs{},
+								},
+								{
+									Name: "InterPodAffinity",
+									Args: &config.InterPodAffinityArgs{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "wasm plugin is in the config",
+			args: args{
+				cc: &config.KubeSchedulerConfiguration{
+					Profiles: []config.KubeSchedulerProfile{
+						{
+							SchedulerName: "default-scheduler",
+							Plugins: &config.Plugins{
+								MultiPoint: config.PluginSet{
+									Enabled: []config.Plugin{
+										{Name: "DefaultPreemption"},
+										{Name: "InterPodAffinity"},
+										{Name: "wasm1"},
+									},
+								},
+							},
+							PluginConfig: []config.PluginConfig{
+								{
+									Name: "DefaultPreemption",
+									Args: &config.DefaultPreemptionArgs{},
+								},
+								{
+									Name: "InterPodAffinity",
+									Args: &config.InterPodAffinityArgs{},
+								},
+								{
+									Name: "wasm1",
+									Args: &runtime.Unknown{
+										// TODO: need to make the wasm config implements runtime.Object.
+										Raw: []byte(`{"guestURL":"https://example.com/hoge.wasm"}`),
+									},
+								},
+								{
+									// wasm2 is in the config, but not enabled.
+									Name: "wasm2",
+									Args: &runtime.Unknown{
+										// TODO: need to make the wasm config implements runtime.Object.
+										Raw: []byte(`{"guestURL":"https://example.com/hoge.wasm"}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"wasm1"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := getWasmPluginNames(tt.args.cc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getWasmPluginNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -109,6 +109,7 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
+github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTrLC1F86HID8=

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -129,7 +129,7 @@ func (pl *wasmPlugin) plugin() *wasmPlugin {
 var _ framework.Plugin = (*wasmPlugin)(nil)
 
 // Name implements the same method as documented on framework.Plugin.
-// See /RATIONALE.md for impact
+// The plugin name is defined by the scheduler configuration.
 func (pl *wasmPlugin) Name() string {
 	return pl.pluginName
 }

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -31,26 +31,19 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 )
 
-// PluginName is static as app.WithPlugin needs to set the name *prior* to
-// reading configuration from New. This means it cannot see any properties
-// there including the path to the wasm binary.
-const PluginName = "wasm"
-
-var _ frameworkruntime.PluginFactory = New
-
-// New initializes a new plugin and returns it.
-func New(configuration runtime.Object, frameworkHandle framework.Handle) (framework.Plugin, error) {
-	config := PluginConfig{}
-	if err := frameworkruntime.DecodeInto(configuration, &config); err != nil {
-		return nil, fmt.Errorf("wasm: failed to decode into PluginConfig: %w", err)
+func PluginFactory(pluginName string) frameworkruntime.PluginFactory {
+	return func(configuration runtime.Object, frameworkHandle framework.Handle) (framework.Plugin, error) {
+		config := PluginConfig{}
+		if err := frameworkruntime.DecodeInto(configuration, &config); err != nil {
+			return nil, fmt.Errorf("failed to decode into %s PluginConfig: %w", pluginName, err)
+		}
+		return NewFromConfig(context.Background(), pluginName, config)
 	}
-
-	return NewFromConfig(context.Background(), config)
 }
 
 // NewFromConfig is like New, except it allows us to explicitly provide the
 // context and configuration of the plugin. This allows flexibility in tests.
-func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, error) {
+func NewFromConfig(ctx context.Context, pluginName string, config PluginConfig) (framework.Plugin, error) {
 	url := config.GuestURL
 	if url == "" {
 		return nil, errors.New("wasm: guestURL is required")
@@ -65,7 +58,7 @@ func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, 
 		return nil, err
 	}
 
-	pl, err := newWasmPlugin(ctx, runtime, guestModule, config)
+	pl, err := newWasmPlugin(ctx, pluginName, runtime, guestModule, config)
 	if err != nil {
 		_ = runtime.Close(ctx)
 		return nil, err
@@ -83,7 +76,7 @@ func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, 
 
 // newWasmPlugin is extracted to prevent small bugs: The caller must close the
 // wazero.Runtime to avoid leaking mmapped files.
-func newWasmPlugin(ctx context.Context, runtime wazero.Runtime, guestModule wazero.CompiledModule, config PluginConfig) (*wasmPlugin, error) {
+func newWasmPlugin(ctx context.Context, pluginName string, runtime wazero.Runtime, guestModule wazero.CompiledModule, config PluginConfig) (*wasmPlugin, error) {
 	var guestInterfaces interfaces
 	var err error
 	if guestInterfaces, err = detectInterfaces(guestModule.ExportedFunctions()); err != nil {
@@ -93,6 +86,7 @@ func newWasmPlugin(ctx context.Context, runtime wazero.Runtime, guestModule waze
 	}
 
 	pl := &wasmPlugin{
+		pluginName:        pluginName,
 		runtime:           runtime,
 		guestModule:       guestModule,
 		guestArgs:         config.Args,
@@ -108,6 +102,7 @@ func newWasmPlugin(ctx context.Context, runtime wazero.Runtime, guestModule waze
 }
 
 type wasmPlugin struct {
+	pluginName        string
 	runtime           wazero.Runtime
 	guestModule       wazero.CompiledModule
 	guestInterfaces   interfaces
@@ -136,7 +131,7 @@ var _ framework.Plugin = (*wasmPlugin)(nil)
 // Name implements the same method as documented on framework.Plugin.
 // See /RATIONALE.md for impact
 func (pl *wasmPlugin) Name() string {
-	return PluginName
+	return pl.pluginName
 }
 
 var _ framework.EnqueueExtensions = (*wasmPlugin)(nil)

--- a/scheduler/plugin/plugin_test.go
+++ b/scheduler/plugin/plugin_test.go
@@ -45,7 +45,7 @@ var ctx = context.Background()
 
 // Test_guestPool_bindingCycles tests that the bindingCycles field is set correctly.
 func Test_guestPool_bindingCycles(t *testing.T) {
-	p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: test.URLTestCycleState})
+	p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: test.URLTestCycleState})
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -123,7 +123,7 @@ func Test_guestPool_bindingCycles(t *testing.T) {
 
 // Test_guestPool_assignedToSchedulingPod tests that the scheduledPodUID is assigned during PreFilter expectedly.
 func Test_guestPool_assignedToSchedulingPod(t *testing.T) {
-	p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: test.URLTestCycleState})
+	p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: test.URLTestCycleState})
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestNew_maskInterfaces(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := wasm.New(&runtime.Unknown{
+			p, err := wasm.PluginFactory("wasm")(&runtime.Unknown{
 				ContentType: runtime.ContentTypeJSON,
 				Raw:         []byte(fmt.Sprintf(`{"guestURL": "%s"}`, tc.guestURL)),
 			}, nil)
@@ -292,7 +292,7 @@ wasm stack trace:
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: tc.guestURL})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: tc.guestURL})
 			if err != nil {
 				if want, have := tc.expectedError, err.Error(); want != have {
 					t.Fatalf("unexpected error: want %v, have %v", want, have)
@@ -342,7 +342,7 @@ func TestEnqueue(t *testing.T) {
 				guestURL = test.URLTestCycleState
 			}
 
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -358,7 +358,7 @@ func TestEnqueue(t *testing.T) {
 	t.Run("panic", func(t *testing.T) {
 		guestURL := test.URLErrorPanicOnEnqueue
 
-		p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL})
+		p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -450,7 +450,7 @@ wasm stack trace:
 				guestURL = test.URLTestFilter
 			}
 
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL, Args: tc.args, GuestConfig: tc.guestConfig})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL, Args: tc.args, GuestConfig: tc.guestConfig})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -537,7 +537,7 @@ wasm stack trace:
 				guestURL = test.URLTestFilter
 			}
 
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -633,7 +633,7 @@ wasm stack trace:
 				guestURL = test.URLTestScore
 			}
 
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
 			if tc.expectedError != "" {
 				requireError(t, err, tc.expectedError)
 				return
@@ -752,7 +752,7 @@ wasm stack trace:
 				guestURL = test.URLTestScore
 			}
 
-			p, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
+			p, err := wasm.NewFromConfig(ctx, "wasm", wasm.PluginConfig{GuestURL: guestURL, Args: tc.args})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes the entry point to read the scheduler configuration before it initializes the scheduler (app.NewSchedulerCommand) and allows us to have multiple wasm plugins.

```yaml
apiVersion: kubescheduler.config.k8s.io/v1
kind: KubeSchedulerConfiguration
profiles:
  - plugins:
      multipoint:
        enabled:
           - name: wasmplugin1
           - name: wasmplugin2
     pluginConfig:
       - name: wasmplugin1
          args:
            guestPath: "/path/to/wasm-plugin1"
       - name: wasmplugin2
          args:
            guestPath: "/path/to/wasm-plugin2"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler can have multiple wasm plugins.
```

#### What are the benchmark results of this change?
<!--
If documentation-only or trivial, just write "N/A". Otherwise, run the following:

1. `make bench-plugin > before.txt` on the commit prior to your changes
2. `make bench-plugin > after.txt` on the commit of your changes
3. Paste the output of `benchstat before.txt after.txt` as a code block.

If you haven't yet installed benchstat, it looks like this.
```
$ go install golang.org/x/perf/cmd/benchstat@latest
```

-->
```benchstat
N/A (no benchmark related area in this change.)
```
