### PR TITLE
Run codec benchmarks in wasm

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/tetratelabs/wazero v1.3.0
 	k8s.io/api v0.27.3
 	k8s.io/kubernetes v1.27.3
-	sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/kube-scheduler-wasm-extension/scheduler v0.0.0-00010101000000-000000000000
 )
 

--- a/internal/e2e/guest/go.mod
+++ b/internal/e2e/guest/go.mod
@@ -1,0 +1,18 @@
+module sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/guest
+
+go 1.20
+
+require (
+	github.com/wasilibs/nottinygc v0.3.0
+	sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/magefile/mage v1.14.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+)
+
+replace sigs.k8s.io/kube-scheduler-wasm-extension/guest => ./../../../guest
+
+replace sigs.k8s.io/kube-scheduler-wasm-extension/kubernetes/proto => ./../../../kubernetes/proto

--- a/internal/e2e/guest/go.sum
+++ b/internal/e2e/guest/go.sum
@@ -1,0 +1,12 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/wasilibs/nottinygc v0.3.0 h1:0L1jsJ1MsyN5tdinmFbLfuEA0TnHRcqaBM9pDTJVJmU=
+github.com/wasilibs/nottinygc v0.3.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/internal/e2e/scheduler/scheduler_test.go
+++ b/internal/e2e/scheduler/scheduler_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package e2e_test
+package scheduler_test
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 
 // TestGuest_CycleStateCoherence ensures cycle state data is coherent in a
 // scheduling context.
-func TestGuest_CycleStateCoherence(t *testing.T) {
+func TestCycleStateCoherence(t *testing.T) {
 	ctx := context.Background()
 
 	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestPath: test.PathTestCycleState})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This changes the guest codec benchmarks to actually run in wasm. By using TinyGo with wazero, we can see performance of unmarshal realistically. Before, the benchmarks were run in normal go, even if they used the same library as the guest used.

When you run `make bench`, tinygo compiles the benchmarks to wasm, and then runs that wasm with wazero. So, the console output is coming from wasm functions compiled from Go benchmarks.

Our makefile ensures that the wazero version is the same as what the scheduler plugin uses (via go.mod). Since the wazero command configures the module to use real clocks, the performance report should be accurate.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

This doesn't solve for real data yet because I can't get the yaml to proto converter to work in TinyGo. We may want to check in serialized protos as they aren't that big.

#### Does this PR introduce a user-facing change?

NONE

#### What are the benchmark results of this change?

```bash
$ make bench-guest
BenchmarkUnmarshalVT/node:_small        	 1588876	       761.6 ns/op
BenchmarkUnmarshalVT/node:_small        	 1553385	       756.4 ns/op
BenchmarkUnmarshalVT/node:_small        	 1608015	       779.7 ns/op
BenchmarkUnmarshalVT/node:_small        	 1602940	       750.1 ns/op
BenchmarkUnmarshalVT/node:_small        	 1573089	       774.9 ns/op
BenchmarkUnmarshalVT/node:_small        	 1599826	       750.2 ns/op
BenchmarkUnmarshalVT/pod:_small         	  475982	      2544 ns/op
BenchmarkUnmarshalVT/pod:_small         	  476852	      2552 ns/op
BenchmarkUnmarshalVT/pod:_small         	  478239	      2610 ns/op
BenchmarkUnmarshalVT/pod:_small         	  438692	      2533 ns/op
BenchmarkUnmarshalVT/pod:_small         	  480537	      2503 ns/op
BenchmarkUnmarshalVT/pod:_small         	  484261	      2521 ns/op
PASS
ok  	sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/guest	20.972s
```
