### PR TITLE
config: add support to file:// and http(s):// URIs

### DIFF
--- a/internal/e2e/profiler/profiler.go
+++ b/internal/e2e/profiler/profiler.go
@@ -67,7 +67,7 @@ func main() {
 	)
 
 	// Pass the profiling context to the plugin.
-	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestPath: guestPath})
+	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: "file://" + guestPath})
 	if err != nil {
 		log.Panicln("failed to create plugin:", err)
 	}

--- a/internal/e2e/scheduler/scheduler_test.go
+++ b/internal/e2e/scheduler/scheduler_test.go
@@ -35,7 +35,7 @@ import (
 func TestCycleStateCoherence(t *testing.T) {
 	ctx := context.Background()
 
-	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestPath: test.PathTestCycleState})
+	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{GuestURL: test.URLTestCycleState})
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -116,7 +116,7 @@ func BenchmarkExample_NodeNumber(b *testing.B) {
 
 func newNodeNumberPlugin(ctx context.Context, t e2e.Testing, reverse bool) framework.Plugin {
 	plugin, err := wasm.NewFromConfig(ctx, wasm.PluginConfig{
-		GuestPath:   test.PathExampleNodeNumber,
+		GuestURL:    test.URLExampleNodeNumber,
 		GuestConfig: fmt.Sprintf(`{"reverse": %v}`, reverse),
 	})
 	if err != nil {

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -36,6 +36,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.3.1
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
@@ -90,6 +91,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/scheduler/plugin/config.go
+++ b/scheduler/plugin/config.go
@@ -17,8 +17,10 @@
 package wasm
 
 type PluginConfig struct {
-	// GuestPath is the path to the guest wasm.
-	GuestPath string `json:"guestPath"`
+	// GuestURL is the URL to the guest wasm.
+	// Valid schemes are file:// for a local file or http[s]:// for one
+	// retrieved via HTTP.
+	GuestURL string `json:"guestURL"`
 
 	// GuestConfig is any configuration to give to the guest.
 	GuestConfig string `json:"guestConfig"`

--- a/scheduler/plugin/http.go
+++ b/scheduler/plugin/http.go
@@ -46,18 +46,19 @@ func (f *httpClient) get(ctx context.Context, u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	resp, err := f.c.Do(req.WithContext(ctx))
+	defer func() {
+		io.Copy(io.Discard, resp.Body) //nolint
+		resp.Body.Close()
+	}()
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(io.Discard, resp.Body) //nolint
-		resp.Body.Close()
 		return nil, fmt.Errorf("received %v status code from %q", resp.StatusCode, u)
 	}
 
 	bytes, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/plugin/http.go
+++ b/scheduler/plugin/http.go
@@ -1,0 +1,65 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package wasm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// httpClient decorates an http.Client with convenience methods.
+type httpClient struct {
+	c http.Client
+}
+
+// newHTTPFetcher is a constructor for httpFetcher.
+//
+// It is possible to plug a custom http.RoundTripper to handle other concerns (e.g. retries)
+// Compression is handled transparently and automatically by http.Client.
+func newHTTPCLient(transport http.RoundTripper) *httpClient {
+	return &httpClient{
+		c: http.Client{Transport: transport},
+	}
+}
+
+// fetch returns a byte slice of the wasm module found at the given URL, or an error otherwise.
+func (f *httpClient) get(ctx context.Context, u *url.URL) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := f.c.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body) //nolint
+		resp.Body.Close()
+		return nil, fmt.Errorf("received %v status code from %q", resp.StatusCode, u)
+	}
+
+	bytes, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}

--- a/scheduler/plugin/http.go
+++ b/scheduler/plugin/http.go
@@ -29,17 +29,17 @@ type httpClient struct {
 	c http.Client
 }
 
-// newHTTPFetcher is a constructor for httpFetcher.
+// newHTTPClient is a constructor for httpFetcher.
 //
 // It is possible to plug a custom http.RoundTripper to handle other concerns (e.g. retries)
 // Compression is handled transparently and automatically by http.Client.
-func newHTTPCLient(transport http.RoundTripper) *httpClient {
+func newHTTPClient(transport http.RoundTripper) *httpClient {
 	return &httpClient{
 		c: http.Client{Transport: transport},
 	}
 }
 
-// fetch returns a byte slice of the wasm module found at the given URL, or an error otherwise.
+// get returns a byte slice of the wasm module found at the given URL, or an error otherwise.
 func (f *httpClient) get(ctx context.Context, u *url.URL) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/scheduler/plugin/http_test.go
+++ b/scheduler/plugin/http_test.go
@@ -1,0 +1,89 @@
+/*
+   Copyright 2023 The Kubernetes Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package wasm
+
+import (
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var wasmMagicNumber = []byte{0x00, 0x61, 0x73, 0x6d}
+
+func TestWasmHTTPFetch(t *testing.T) {
+	wasmBinary := wasmMagicNumber
+	wasmBinary = append(wasmBinary, 0x00, 0x00, 0x00, 0x00)
+	cases := []struct {
+		name          string
+		handler       http.HandlerFunc
+		expectedError string
+	}{
+		{
+			name: "plain wasm binary",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(wasmBinary)
+			},
+		},
+		// Compressed payloads are handled automatically by http.Client.
+		{
+			name: "compressed payload",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Encoding", "gzip")
+
+				gw := gzip.NewWriter(w)
+				defer gw.Close()
+				_, _ = gw.Write(wasmBinary)
+			},
+		},
+		{
+			name: "http error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectedError: "received 500 status code",
+		},
+	}
+
+	for _, proto := range []string{"http", "https"} {
+		t.Run(proto, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					ts := httptest.NewServer(tc.handler)
+					defer ts.Close()
+					c := newHTTPCLient(http.DefaultTransport)
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					parse, err := url.Parse(ts.URL)
+					require.NoError(t, err)
+					_, err = c.get(ctx, parse)
+					if tc.expectedError != "" {
+						require.ErrorContains(t, err, tc.expectedError)
+						return
+					}
+					require.NoError(t, err, "Wasm download got an unexpected error: %v", err)
+				})
+			}
+		})
+	}
+}

--- a/scheduler/plugin/http_test.go
+++ b/scheduler/plugin/http_test.go
@@ -71,7 +71,7 @@ func TestWasmHTTPFetch(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					ts := httptest.NewServer(tc.handler)
 					defer ts.Close()
-					c := newHTTPCLient(http.DefaultTransport)
+					c := newHTTPClient(http.DefaultTransport)
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()
 					parse, err := url.Parse(ts.URL)

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -88,7 +88,7 @@ func readFromURI(ctx context.Context, u string) ([]byte, error) {
 	case "file":
 		return os.ReadFile(uri.Path)
 	case "http", "https":
-		c := newHTTPCLient(http.DefaultTransport)
+		c := newHTTPClient(http.DefaultTransport)
 		return c.get(ctx, uri)
 	default:
 		return nil, fmt.Errorf("unsupported URL scheme: %s", uri.Scheme)

--- a/scheduler/plugin/plugin.go
+++ b/scheduler/plugin/plugin.go
@@ -19,6 +19,8 @@ package wasm
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"sync/atomic"
 	"time"
@@ -51,9 +53,9 @@ func New(configuration runtime.Object, frameworkHandle framework.Handle) (framew
 // NewFromConfig is like New, except it allows us to explicitly provide the
 // context and configuration of the plugin. This allows flexibility in tests.
 func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, error) {
-	guestBin, err := os.ReadFile(config.GuestPath)
+	guestBin, err := readFromURI(ctx, config.GuestURL)
 	if err != nil {
-		return nil, fmt.Errorf("wasm: error reading guest binary at %s: %w", config.GuestPath, err)
+		return nil, fmt.Errorf("wasm: error reading guest binary at %s: %w", config.GuestURL, err)
 	}
 
 	runtime, guestModule, err := prepareRuntime(ctx, guestBin, config.GuestConfig)
@@ -74,6 +76,22 @@ func NewFromConfig(ctx context.Context, config PluginConfig) (framework.Plugin, 
 		return nil, err
 	} else {
 		return pl, nil
+	}
+}
+
+func readFromURI(ctx context.Context, u string) ([]byte, error) {
+	uri, err := url.ParseRequestURI(u)
+	if err != nil {
+		return nil, err
+	}
+	switch uri.Scheme {
+	case "file":
+		return os.ReadFile(uri.Path)
+	case "http", "https":
+		c := newHTTPCLient(http.DefaultTransport)
+		return c.get(ctx, uri)
+	default:
+		return nil, fmt.Errorf("unsupported URL scheme: %s", uri.Scheme)
 	}
 }
 

--- a/scheduler/test/testdata.go
+++ b/scheduler/test/testdata.go
@@ -16,43 +16,43 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 )
 
-var PathErrorNotPlugin = pathWatError("not_plugin")
+var URLErrorNotPlugin = localURL(pathWatError("not_plugin"))
 
-var PathErrorPanicOnGetConfig = pathWatError("panic_on_get_config")
+var URLErrorPanicOnGetConfig = localURL(pathWatError("panic_on_get_config"))
 
-var PathErrorPanicOnEnqueue = pathWatError("panic_on_enqueue")
+var URLErrorPanicOnEnqueue = localURL(pathWatError("panic_on_enqueue"))
 
-var PathErrorPanicOnPreFilter = pathWatError("panic_on_prefilter")
+var URLErrorPanicOnPreFilter = localURL(pathWatError("panic_on_prefilter"))
 
-var PathErrorPanicOnFilter = pathWatError("panic_on_filter")
+var URLErrorPanicOnFilter = localURL(pathWatError("panic_on_filter"))
 
-var PathErrorPanicOnPreScore = pathWatError("panic_on_prescore")
+var URLErrorPanicOnPreScore = localURL(pathWatError("panic_on_prescore"))
 
-var PathErrorPreScoreWithoutScore = pathWatError("prescore_without_score")
+var URLErrorPreScoreWithoutScore = localURL(pathWatError("prescore_without_score"))
 
-var PathErrorPanicOnScore = pathWatError("panic_on_score")
+var URLErrorPanicOnScore = localURL(pathWatError("panic_on_score"))
 
-var PathErrorPanicOnStart = pathWatError("panic_on_start")
+var URLErrorPanicOnStart = localURL(pathWatError("panic_on_start"))
 
-var PathExampleNodeNumber = pathTinyGoExample("nodenumber")
+var URLExampleNodeNumber = localURL(pathTinyGoExample("nodenumber"))
 
-var PathTestAll = pathTinyGoTest("all")
+var URLTestAll = localURL(pathTinyGoTest("all"))
 
-var PathTestAllNoopWat = pathWatTest("all_noop")
+var URLTestAllNoopWat = localURL(pathWatTest("all_noop"))
 
-var PathTestCycleState = pathTinyGoTest("cyclestate")
+var URLTestCycleState = localURL(pathTinyGoTest("cyclestate"))
 
-var PathTestPreFilterFromGlobal = pathWatTest("prefilter_from_global")
+var URLTestPreFilterFromGlobal = localURL(pathWatTest("prefilter_from_global"))
 
-var PathTestFilter = pathTinyGoTest("filter")
+var URLTestFilter = localURL(pathTinyGoTest("filter"))
 
-var PathTestFilterFromGlobal = pathWatTest("filter_from_global")
+var URLTestFilterFromGlobal = localURL(pathWatTest("filter_from_global"))
 
-var PathTestPreScoreFromGlobal = pathWatTest("prescore_from_global")
+var URLTestPreScoreFromGlobal = localURL(pathWatTest("prescore_from_global"))
 
-var PathTestScore = pathTinyGoTest("score")
+var URLTestScore = localURL(pathTinyGoTest("score"))
 
-var PathTestScoreFromGlobal = pathWatTest("score_from_global")
+var URLTestScoreFromGlobal = localURL(pathWatTest("score_from_global"))
 
 //go:embed testdata/yaml/node.yaml
 var yamlNodeReal string
@@ -64,7 +64,7 @@ var NodeReal = func() *v1.Node {
 	return &node
 }()
 
-// NodeSmall is the smallest node that works with PathExampleFilterSimple.
+// NodeSmall is the smallest node that works with URLExampleFilterSimple.
 var NodeSmall = &v1.Node{ObjectMeta: apimeta.ObjectMeta{Name: "good-node"}}
 
 //go:embed testdata/yaml/pod.yaml
@@ -77,7 +77,7 @@ var PodReal = func() *v1.Pod {
 	return &pod
 }()
 
-// PodSmall is the smallest pod that works with PathExampleFilterSimple.
+// PodSmall is the smallest pod that works with URLExampleFilterSimple.
 var PodSmall = &v1.Pod{
 	ObjectMeta: apimeta.ObjectMeta{
 		Name:      "good-pod",
@@ -102,28 +102,33 @@ func decodeYaml[O apiruntime.Object](yaml string, object O) {
 	}
 }
 
+// localURL prefixes file:// to a given path.
+func localURL(path string) string {
+	return "file://" + path
+}
+
 // pathTinyGoExample gets the absolute path to a given TinyGo example.
 func pathTinyGoExample(name string) string {
-	return relativePath(path.Join("..", "..", "examples", name, "main.wasm"))
+	return relativeURL(path.Join("..", "..", "examples", name, "main.wasm"))
 }
 
 // pathTinyGoTest gets the absolute path to a given TinyGo test.
 func pathTinyGoTest(name string) string {
-	return relativePath(path.Join("..", "..", "guest", "testdata", name, "main.wasm"))
+	return relativeURL(path.Join("..", "..", "guest", "testdata", name, "main.wasm"))
 }
 
 // pathWatError gets the absolute path wasm compiled from a %.wat source.
 func pathWatError(name string) string {
-	return relativePath(path.Join("testdata", "error", name+".wasm"))
+	return relativeURL(path.Join("testdata", "error", name+".wasm"))
 }
 
 // pathWatTest gets the absolute path wasm compiled from a %.wat source.
 func pathWatTest(name string) string {
-	return relativePath(path.Join("testdata", "test", name+".wasm"))
+	return relativeURL(path.Join("testdata", "test", name+".wasm"))
 }
 
-// relativePath gets the absolute from this file.
-func relativePath(fromThisFile string) string {
+// relativeURL gets the absolute from this file.
+func relativeURL(fromThisFile string) string {
 	_, thisFile, _, ok := runtime.Caller(1)
 	if !ok {
 		panic("cannot determine current path")


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

/kind api-change

#### What this PR does / why we need it:

Extends the current plugin config to use instead a URI. In the case of `file://` the behavior is the same as it is currently. In the case of `http(s)://` it will fetch the URI and try to evaluate it as a wasm payload.

This PR is based on earlier work on `dapr/component-contrib`. See: https://github.com/dapr/components-contrib/pull/3005


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a will create if required.

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

Changes `PluginConfig.ConfigPath` to `PluginConfig.ConfigURL`. A local path must now be prefixed with `file://`. A local path will be of the form `file://relativepath/myfile.wasm` or `file:///absolute/path/to/myfile.wasm`.

```

#### What are the benchmark results of this change?

n/a