### PR TITLE
chore: wazero v1.6.0 version bump

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -6,7 +6,7 @@ go 1.20
 require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/stealthrocket/wzprof v0.1.5
-	github.com/tetratelabs/wazero v1.3.1
+	github.com/tetratelabs/wazero v1.6.0
 	go.uber.org/zap v1.19.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -407,8 +407,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.3.1 h1:rnb9FgOEQRLLR8tgoD1mfjNjMhFeWRUk+a4b4j/GpUM=
-github.com/tetratelabs/wazero v1.3.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
+github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -37,7 +37,7 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/tetratelabs/wazero v1.3.1
+	github.com/tetratelabs/wazero v1.6.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -321,8 +321,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.3.1 h1:rnb9FgOEQRLLR8tgoD1mfjNjMhFeWRUk+a4b4j/GpUM=
-github.com/tetratelabs/wazero v1.3.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
+github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi, this is Edoardo from the wazero team. I am opening this PR to upgrade to the latest version and will stick around to help with reviewing some PRs! If you need some help especially with Wasm feel free to ping me here or on the k8s/Gophers Slack!

This upgrades to wazero [v1.6.0]. This release notably introduces a new
experimental optimizing compiler backend for arm64.

As compared to v1.3.0, cumulatively this upgrade brings several
stability enhancements; including compiler bugs, improvements to WASI
support, especially when paired with the newer Go `GOOS=wasip1` backend,
and fixes to a potential memory leak.

Read more on the previous release notes ([v1.3.1][v1.3.1],
[v1.4.0][v1.4.0], [v1.5.0][v1.5.0])

[v1.3.1]: https://github.com/tetratelabs/wazero/releases/tag/v1.3.1
[v1.4.0]: https://github.com/tetratelabs/wazero/releases/tag/v1.4.0
[v1.5.0]: https://github.com/tetratelabs/wazero/releases/tag/v1.5.0
[v1.6.0]: https://github.com/tetratelabs/wazero/releases/tag/v1.6.0

/kind cleanup

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>



```benchstat
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/scheduler
                                       │ bench-example-before.txt │      bench-example-after.txt       │
                                       │          sec/op          │    sec/op     vs base              │
Example_NodeNumber/Simple/New-10                     65.91m ±  1%   65.63m ±  0%       ~ (p=0.093 n=6)
Example_NodeNumber/Simple/Run-10                     160.9µ ± 23%   162.6µ ± 21%       ~ (p=0.818 n=6)
Example_NodeNumber/Simple_Log/New-10                 65.96m ±  0%   65.49m ±  1%  -0.71% (p=0.026 n=6)
Example_NodeNumber/Simple_Log/Run-10                 180.0µ ±  6%   180.4µ ±  5%       ~ (p=0.937 n=6)
Example_NodeNumber/Advanced/New-10                   79.86m ±  1%   78.02m ±  0%  -2.30% (p=0.002 n=6)
Example_NodeNumber/Advanced/Run-10                   74.40µ ±  0%   74.17µ ±  0%  -0.31% (p=0.002 n=6)
Example_NodeNumber/Advanced_Log/New-10               79.55m ±  1%   78.30m ±  1%  -1.57% (p=0.002 n=6)
Example_NodeNumber/Advanced_Log/Run-10               82.37µ ±  0%   81.96µ ±  0%  -0.50% (p=0.002 n=6)
geomean                                              2.893m         2.876m        -0.57%
```
