### PR TITLE
deps: updates wazero to v1.7.0

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -6,7 +6,7 @@ go 1.20
 require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/stealthrocket/wzprof v0.1.5
-	github.com/tetratelabs/wazero v1.6.0
+	github.com/tetratelabs/wazero v1.7.0-pre.1
 	go.uber.org/zap v1.19.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -6,7 +6,7 @@ go 1.20
 require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/stealthrocket/wzprof v0.1.5
-	github.com/tetratelabs/wazero v1.7.0-pre.1
+	github.com/tetratelabs/wazero v1.7.0
 	go.uber.org/zap v1.19.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -407,8 +407,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
-github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
+github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -407,8 +407,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
-github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
+github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
+github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -37,7 +37,7 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/tetratelabs/wazero v1.6.0
+	github.com/tetratelabs/wazero v1.7.0-pre.1
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -37,7 +37,7 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/tetratelabs/wazero v1.7.0-pre.1
+	github.com/tetratelabs/wazero v1.7.0
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -321,8 +321,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
-github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
+github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -321,8 +321,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
-github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
+github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
+github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This will update [wazero](https://wazero.io/) to v1.7.0. The v1.7.0. release marks a milestone in the wazero project, replacing our old compiler architecture with a [new optimizing compiler backend.][docs]. It also introduces experimental support to the thread spec.

We will officially announce the final v1.7.0 release in just a few days, during [Wasm I/O](https://wasmio.tech/), after which we will undraft this PR and update it to the latest tag.

~Let me know if you'd rather merge this PR before the official release. This draft PR is intended to let your CI checks run and verify everything is in order before our final release.~

[docs]: https://wazero.io/docs/how_the_optimizing_compiler_works/

#### What type of PR is this?

/kind feature


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### What are the benchmark results of this change?

the optimizing compiler brings >40% run-time improvement at the cost of slightly slower compile-time; that is a one-time cost you only pay at boot time, and we can setup a persistent file cache if that's an issue

```benchstat
❯ benchstat before-run.txt after-run.txt
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/scheduler
                                       │ before-run.txt │            after-run.txt            │
                                       │     sec/op     │    sec/op     vs base               │
Example_NodeNumber/Simple/Run-10           166.7µ ± 24%   101.8µ ± 24%  -38.93% (p=0.002 n=6)
Example_NodeNumber/Simple_Log/Run-10       184.9µ ±  9%   116.4µ ±  8%  -37.04% (p=0.002 n=6)
Example_NodeNumber/Advanced/Run-10         78.21µ ±  4%   39.62µ ±  1%  -49.34% (p=0.002 n=6)
Example_NodeNumber/Advanced_Log/Run-10     83.73µ ±  4%   46.14µ ±  1%  -44.89% (p=0.002 n=6)
geomean                                    119.2µ         68.22µ        -42.76%
```

compile-time:

```benchstat
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/scheduler
                                       │ before.txt  │              after.txt               │
                                       │   sec/op    │    sec/op     vs base                │
Example_NodeNumber/Simple/New-10         67.39m ± 1%   612.24m ± 1%  +808.45% (p=0.002 n=6)
Example_NodeNumber/Simple_Log/New-10     67.55m ± 1%   604.96m ± 2%  +795.55% (p=0.002 n=6)
Example_NodeNumber/Advanced/New-10       80.16m ± 1%   673.40m ± 1%  +740.05% (p=0.002 n=6)
Example_NodeNumber/Advanced_Log/New-10   80.73m ± 1%   673.02m ± 1%  +733.64% (p=0.002 n=6)
geomean                                  73.67m         640.1m       +768.80%
```
