### PR TITLE
Only start the extender plugin when needed in scheduler-perf

### DIFF
--- a/internal/e2e/scheduler_perf/scheduler_perf_test.go
+++ b/internal/e2e/scheduler_perf/scheduler_perf_test.go
@@ -762,9 +762,11 @@ func runWorkload(ctx context.Context, b *testing.B, tc *testCase, w *workload) [
 	finalFunc, podInformer, client, dynClient := mustSetupScheduler(ctx, b, cfg, registory)
 	b.Cleanup(finalFunc)
 
-	// start extender
-	go extender.Start()
-	defer extender.Shutdown()
+	// Start extender if needed.
+	if cfg != nil && len(cfg.Extenders) > 0 {
+		go extender.Start()
+		defer extender.Shutdown()
+	}
 
 	var mu sync.Mutex
 	var dataItems []DataItem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR simply changes how we run the `scheduler-perf` benchmarks by only starting the extender plugin when it's referenced in the configuration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### What are the benchmark results of this change?
<!--
If documentation-only or trivial, just write "N/A". Otherwise, run the following:

1. `make bench-example > before.txt` on the commit prior to your changes
2. `make bench-example > after.txt` on the commit of your changes
3. Paste the output of `benchstat before.txt after.txt` as a code block.

If you haven't yet installed benchstat, it looks like this.
```
$ go install golang.org/x/perf/cmd/benchstat@latest
```

-->
```benchstat
N/A
```
