### PR TITLE
Upgrade `golangci-lint` to 1.61.0

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.20"
+          - "1.23"
 
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.20"
+          - "1.23"
 
     steps:
       - uses: actions/checkout@v3
@@ -67,9 +67,9 @@ jobs:
     strategy:
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.20"
+          - "1.23"
         tinygo-version:  # Note: TinyGo only supports latest: https://github.com/tinygo-org/tinygo/releases
-          - "0.28.1"  # Latest
+          - "0.34.0"  # Latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testdata.yaml
+++ b/.github/workflows/testdata.yaml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.20"
+          - "1.23"
         tinygo-version:  # Note: TinyGo only supports latest: https://github.com/tinygo-org/tinygo/releases
-          - "0.28.1"  # Latest
+          - "0.34.0"  # Latest
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 gofumpt       := mvdan.cc/gofumpt@v0.5.0
 gosimports    := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 examples/advanced/main.wasm: examples/advanced/main.go
 	@(cd $(@D); tinygo build -o main.wasm -gc=custom -tags=custommalloc -scheduler=none --no-debug -target=wasi .)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ bench-guest: guest/.tinygo-target.json
 # This makes a wasi target that uses the same wazero version as the scheduler.
 wazero_version := $(shell (cd scheduler; go list -f '{{ .Module.Version }}' github.com/tetratelabs/wazero))
 guest/.tinygo-target.json: scheduler/go.mod
-	@sed 's~"wasmtime.*"~"go run github.com/tetratelabs/wazero/cmd/wazero@$(wazero_version) run {}"~' $(shell tinygo env TINYGOROOT)/targets/wasi.json > $@
+	@jq '."emulator" = "go run github.com/tetratelabs/wazero/cmd/wazero@$(wazero_version) run {}"' $(shell tinygo env TINYGOROOT)/targets/wasi.json > $@
 
 .PHONY: build-wat
 build-wat: $(wildcard scheduler/test/testdata/*/*.wat)

--- a/scheduler/test/util.go
+++ b/scheduler/test/util.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,9 +22,9 @@ type FakeRecorder struct {
 func (f *FakeRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
 	obj, ok := regarding.(*v1.ObjectReference)
 	if !ok || obj.Name == "" {
-		f.EventMsg = fmt.Sprintf(eventtype + " " + reason + " " + action + " " + note)
+		f.EventMsg = eventtype + " " + reason + " " + action + " " + note
 	} else {
-		f.EventMsg = fmt.Sprintf(obj.Name + " " + eventtype + " " + reason + " " + action + " " + note)
+		f.EventMsg = obj.Name + " " + eventtype + " " + reason + " " + action + " " + note
 	}
 }
 


### PR DESCRIPTION
The previous version of `golangci-lint` (1.53.2) crashed under recent versions of Go.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

The `lint` make target currently fails with recent versions of Go (e.g. 1.23.3) because the version of `golangci-lint` that we use crashes at runtime.
Updating to 1.61.0 solves this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

I also had to update the version of Go used in the CI workflows to get them to pass.
I thus updated to the latest version, and did the same for TinyGo.

The latest TinyGo now has multiple `wasi` targets, and the main one inherits from `wasip1`. I had to change the way we generate the test target to deal with this inheritance.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### What are the benchmark results of this change?
<!--
If documentation-only or trivial, just write "N/A". Otherwise, run the following:

1. `make bench-example > before.txt` on the commit prior to your changes
2. `make bench-example > after.txt` on the commit of your changes
3. Paste the output of `benchstat before.txt after.txt` as a code block.

If you haven't yet installed benchstat, it looks like this.
```
$ go install golang.org/x/perf/cmd/benchstat@latest
```

-->
```benchstat
N/A
```
