### PR TITLE
fix nodenumber plugin to use Pod name instead of pod.spec.nodeName

### DIFF
--- a/examples/nodenumber/main.go
+++ b/examples/nodenumber/main.go
@@ -96,7 +96,7 @@ func (pl *NodeNumber) PreScore(state api.CycleState, pod proto.Pod, _ api.NodeIn
 
 	klog.InfoS("execute PreScore on NodeNumber plugin", "pod", klog.KObj(pod))
 
-	podnum, ok := lastNumber(pod.Spec().GetNodeName())
+	podnum, ok := lastNumber(pod.GetName())
 	if !ok {
 		recorder.Eventf(pod, nil, "PreScore", "not match lastNumber", "Skip", "")
 		return nil // return success even if its suffix is non-number.
@@ -116,7 +116,7 @@ func (pl *NodeNumber) Score(state api.CycleState, pod proto.Pod, nodeName string
 		nodenum, ok := lastNumber(nodeName)
 		match = ok && data.(*preScoreState).podSuffixNumber == nodenum
 	} else {
-		// Match is also when there is no pod spec node name.
+		// Match is also when there is no pod name suffix.
 		match = true
 	}
 

--- a/examples/nodenumber/main_test.go
+++ b/examples/nodenumber/main_test.go
@@ -35,11 +35,11 @@ func Test_NodeNumber(t *testing.T) {
 		{name: "empty,empty", pod: &testPod{}, nodeName: "", expectedMatch: true},
 		{name: "empty,letter", pod: &testPod{}, nodeName: "a", expectedMatch: true},
 		{name: "empty,digit", pod: &testPod{}, nodeName: "1", expectedMatch: true},
-		{name: "letter,letter", pod: &testPod{nodeName: "a"}, nodeName: "a", expectedMatch: true},
-		{name: "letter,digit", pod: &testPod{nodeName: "a"}, nodeName: "1", expectedMatch: true},
-		{name: "digit,letter", pod: &testPod{nodeName: "1"}, nodeName: "a", expectedMatch: false},
-		{name: "digit,digit", pod: &testPod{nodeName: "1"}, nodeName: "1", expectedMatch: true},
-		{name: "digit,different digit", pod: &testPod{nodeName: "1"}, nodeName: "2", expectedMatch: false},
+		{name: "letter,letter", pod: &testPod{name: "a"}, nodeName: "a", expectedMatch: true},
+		{name: "letter,digit", pod: &testPod{name: "a"}, nodeName: "1", expectedMatch: true},
+		{name: "digit,letter", pod: &testPod{name: "1"}, nodeName: "a", expectedMatch: false},
+		{name: "digit,digit", pod: &testPod{name: "1"}, nodeName: "1", expectedMatch: true},
+		{name: "digit,different digit", pod: &testPod{name: "1"}, nodeName: "2", expectedMatch: false},
 	}
 
 	for _, reverse := range []bool{false, true} {
@@ -127,7 +127,7 @@ var _ proto.Pod = &testPod{}
 
 // testPod is test data just to set the nodeName
 type testPod struct {
-	nodeName string
+	name string
 }
 
 func (t testPod) GetUid() string {
@@ -135,7 +135,7 @@ func (t testPod) GetUid() string {
 }
 
 func (t testPod) GetName() string {
-	return ""
+	return t.name
 }
 
 func (t testPod) GetNamespace() string {
@@ -163,8 +163,7 @@ func (t testPod) GetAnnotations() map[string]string {
 }
 
 func (t testPod) Spec() *protoapi.PodSpec {
-	nodeName := t.nodeName
-	return &protoapi.PodSpec{NodeName: &nodeName}
+	return &protoapi.PodSpec{}
 }
 
 func (t testPod) Status() *protoapi.PodStatus {

--- a/internal/e2e/scheduler_perf/wasm/nodenumber/main.go
+++ b/internal/e2e/scheduler_perf/wasm/nodenumber/main.go
@@ -97,7 +97,7 @@ func (pl *NodeNumber) EventsToRegister() []api.ClusterEvent {
 
 // PreScore implements api.PreScorePlugin
 func (pl *NodeNumber) PreScore(state api.CycleState, pod proto.Pod, _ api.NodeInfoList) *api.Status {
-	podnum, ok := lastNumber(pod.Spec().GetNodeName())
+	podnum, ok := lastNumber(pod.GetName())
 	if !ok {
 		return nil // return success even if its suffix is non-number.
 	}
@@ -113,7 +113,7 @@ func (pl *NodeNumber) Score(state api.CycleState, pod proto.Pod, nodeName string
 		nodenum, ok := lastNumber(nodeName)
 		match = ok && data.(*preScoreState).podSuffixNumber == nodenum
 	} else {
-		// Match is also when there is no pod spec node name.
+		// Match is also when there is no pod name suffix.
 		match = true
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The nodeNumber plugin is intended to scores higher if the node name and pod name suffixes match.
But in implementation, it uses Pod's .`Spec.nodeName` not a `.metadata.Name`.
So PreScore allways return nothing, and therefore allways `match=true` in Score.

This PR fix this problem
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
change nodeNumber plugin to follow specification.
```

#### What are the benchmark results of this change?
<!--
If documentation-only or trivial, just write "N/A". Otherwise, run the following:

1. `make bench-example > before.txt` on the commit prior to your changes
2. `make bench-example > after.txt` on the commit of your changes
3. Paste the output of `benchstat before.txt after.txt` as a code block.

If you haven't yet installed benchstat, it looks like this.
```
$ go install golang.org/x/perf/cmd/benchstat@latest
```

-->
[after.txt](https://github.com/user-attachments/files/17759131/after.txt)
[before.txt](https://github.com/user-attachments/files/17759122/before.txt)
```benchstat
❯ benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kube-scheduler-wasm-extension/internal/e2e/scheduler
cpu: Apple M1
                                      │  before.txt  │              after.txt              │
                                      │    sec/op    │    sec/op     vs base               │
Example_NodeNumber/Simple/New-8         497.5m ± 14%   506.5m ±  1%        ~ (p=0.394 n=6)
Example_NodeNumber/Simple/Run-8         177.8µ ± 30%   169.1µ ± 10%        ~ (p=0.310 n=6)
Example_NodeNumber/Simple_Log/New-8     531.7m ± 19%   501.5m ±  4%        ~ (p=0.310 n=6)
Example_NodeNumber/Simple_Log/Run-8     206.7µ ± 17%   213.9µ ± 19%        ~ (p=0.310 n=6)
Example_NodeNumber/Advanced/New-8        1.081 ± 12%    1.076 ±  5%        ~ (p=1.000 n=6)
Example_NodeNumber/Advanced/Run-8       62.07µ ±  4%   69.25µ ±  3%  +11.56% (p=0.002 n=6)
Example_NodeNumber/Advanced_Log/New-8    1.084 ± 80%    1.066 ±  4%        ~ (p=0.937 n=6)
Example_NodeNumber/Advanced_Log/Run-8   76.83µ ± 17%   79.26µ ±  2%        ~ (p=0.394 n=6)
geomean                                 9.265m         9.338m         +0.78%
```
