### PR TITLE
fix: allow kube-scheduler to pass through flags other than --config

### DIFF
--- a/scheduler/cmd/scheduler/config.go
+++ b/scheduler/cmd/scheduler/config.go
@@ -17,10 +17,10 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
@@ -36,8 +36,10 @@ import (
 // and return the wasm plugins enabled by the user.
 func getWasmPluginsFromConfig() ([]string, error) {
 	// In the scheduler, the path to the scheduler configuration is specified with --config option.
-	configFile := flag.String("config", "", "")
-	flag.Parse()
+	flagSet := pflag.NewFlagSet("", pflag.ExitOnError)
+	flagSet.ParseErrorsWhitelist.UnknownFlags = true
+	configFile := flagSet.String("config", "", "")
+	flagSet.Parse(os.Args[1:])
 
 	if configFile == nil {
 		// Users don't have the own configuration. do nothing.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

By default, Go’s `flag` package rejects any flags it doesn’t know, so our scheduler wrapper was swallowing all kube-scheduler parameters except `--config`. This PR switches to `spf13/pflag` and enables unknown-flag passthrough, so flags like `--v`, `--secure-port`, and any future additions are correctly forwarded to the real scheduler.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### What are the benchmark results of this change?

```benchstat

```
