### PR TITLE
chore(tutorial): fix YAML indentation in scheduler plugin example

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -33,15 +33,15 @@ profiles:
   - plugins:
       multiPoint:
         enabled:
-           - name: wasmplugin1
-           - name: wasmplugin2
-      pluginConfig:
-       - name: wasmplugin1
-          args:
-            guestURL: "file://path/to/wasm-plugin1.wasm"
-       - name: wasmplugin2
-          args:
-            guestURL: "https://url/to/wasm-plugin2.wasm"
+          - name: wasmplugin1
+          - name: wasmplugin2
+    pluginConfig:
+      - name: wasmplugin1
+        args:
+          guestURL: "file://path/to/wasm-plugin1.wasm"
+      - name: wasmplugin2
+        args:
+          guestURL: "https://url/to/wasm-plugin2.wasm"
 ```
 
 - A wasm plugin **must** be enabled via `multiPoint` even if your wasm plugin only uses some of extension points.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixed the indentation of `pluginConfig` so that it aligns correctly under `profiles`.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### What are the benchmark results of this change?

```benchstat

```
